### PR TITLE
Feat: Browser-native message translation (distinct from UI localization)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 # Pre commit
 /.husky
 tsconfig.tsbuildinfo
+
+# private fork-only notes
+/.fork-local

--- a/src/components/message/MessageActions.tsx
+++ b/src/components/message/MessageActions.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { FaExpand, FaReply, FaTrash } from "react-icons/fa";
+import { FaExpand, FaLanguage, FaReply, FaTrash } from "react-icons/fa";
 import type { MessageType } from "../../types";
 import { MdAddReaction } from "./icons";
 
@@ -7,11 +7,14 @@ interface MessageActionsProps {
   message: MessageType;
   onReplyClick: () => void;
   onReactClick: (buttonElement: Element) => void;
+  onTranslateClick?: () => void;
   onRedactClick?: () => void;
   onOpenMedia?: () => void;
   canRedact?: boolean;
   canReply?: boolean;
+  canTranslate?: boolean;
   canOpenMedia?: boolean;
+  isTranslating?: boolean;
   inline?: boolean;
 }
 
@@ -19,11 +22,14 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
   message,
   onReplyClick,
   onReactClick,
+  onTranslateClick,
   onRedactClick,
   onOpenMedia,
   canRedact = false,
   canReply = !!message.msgid,
+  canTranslate = false,
   canOpenMedia = false,
+  isTranslating = false,
   inline = false,
 }) => {
   return (
@@ -60,6 +66,20 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
           title="Reply"
         >
           <FaReply className="w-4 h-4" />
+        </button>
+      )}
+      {canTranslate && onTranslateClick && (
+        <button
+          type="button"
+          className="px-2.5 py-1.5 text-sky-300/80 hover:text-sky-200 hover:bg-white/10 transition-colors first:rounded-l-lg last:rounded-r-lg disabled:opacity-60 disabled:cursor-wait"
+          onClick={onTranslateClick}
+          title={isTranslating ? "Translating" : "Translate message"}
+          aria-label={
+            isTranslating ? "Translating message" : "Translate message"
+          }
+          disabled={isTranslating}
+        >
+          <FaLanguage className="w-4 h-4" />
         </button>
       )}
       <button

--- a/src/components/message/MessageItem.tsx
+++ b/src/components/message/MessageItem.tsx
@@ -11,6 +11,7 @@ import { useLongPress } from "../../hooks/useLongPress";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import {
   canUseBrowserTranslation,
+  detectMessageSourceLanguage,
   getBrowserTranslationAvailability,
   getMessageSourceLanguage,
   getPreferredTranslationTargetLanguageFromSetting,
@@ -478,7 +479,18 @@ export const MessageItem = memo((props: MessageItemProps) => {
     const targetLanguage = getPreferredTranslationTargetLanguageFromSetting(
       translationTargetLanguage,
     );
-    const sourceLanguage = getMessageSourceLanguage(message.tags);
+    const sourceLanguage =
+      getMessageSourceLanguage(message.tags) ??
+      (await detectMessageSourceLanguage({ text: messageContent }));
+
+    if (!sourceLanguage) {
+      setTranslationState({
+        status: "error",
+        targetLanguage,
+        message: "Could not determine the message language for translation.",
+      });
+      return;
+    }
 
     if (sourceLanguage === targetLanguage) {
       setTranslationState({
@@ -980,9 +992,11 @@ export const MessageItem = memo((props: MessageItemProps) => {
                 </div>
                 {translationState.status === "translated" &&
                   translatedHtmlContent && (
-                    <div className="mt-1 overflow-hidden break-words whitespace-pre-wrap">
-                      {translatedHtmlContent}
-                    </div>
+                    <EnhancedLinkWrapper onIrcLinkClick={onIrcLinkClick}>
+                      <div className="mt-1 overflow-hidden break-words whitespace-pre-wrap">
+                        {translatedHtmlContent}
+                      </div>
+                    </EnhancedLinkWrapper>
                   )}
                 {translationState.status === "downloading" && (
                   <div className="mt-1 text-sky-100/80">

--- a/src/components/message/MessageItem.tsx
+++ b/src/components/message/MessageItem.tsx
@@ -3,6 +3,7 @@ import {
   memo,
   startTransition,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -186,6 +187,8 @@ export const MessageItem = memo((props: MessageItemProps) => {
   const [translationState, setTranslationState] = useState<TranslationState>({
     status: "idle",
   });
+  const activeTranslationAbortRef = useRef<AbortController | null>(null);
+  const activeTranslationRunRef = useRef(0);
   const longPress = useLongPress({
     onLongPress: () => setSheetOpen(true),
   });
@@ -374,6 +377,43 @@ export const MessageItem = memo((props: MessageItemProps) => {
 
   // message.content is already combined for multiline messages by the IRC client
   const messageContent = message.content;
+  const translationMessageKey = `${message.id ?? ""}:${message.msgid ?? ""}:${messageContent}`;
+  const lastTranslationMessageKeyRef = useRef(translationMessageKey);
+
+  const cancelActiveTranslation = useCallback(() => {
+    activeTranslationRunRef.current += 1;
+    activeTranslationAbortRef.current?.abort();
+    activeTranslationAbortRef.current = null;
+  }, []);
+
+  const beginTranslationRun = useCallback(() => {
+    activeTranslationAbortRef.current?.abort();
+
+    const controller = new AbortController();
+    const runId = activeTranslationRunRef.current + 1;
+
+    activeTranslationRunRef.current = runId;
+    activeTranslationAbortRef.current = controller;
+
+    return { controller, runId };
+  }, []);
+
+  const isActiveTranslationRun = useCallback(
+    (runId: number, signal?: AbortSignal) =>
+      activeTranslationRunRef.current === runId && !(signal?.aborted ?? false),
+    [],
+  );
+
+  useEffect(() => {
+    if (lastTranslationMessageKeyRef.current !== translationMessageKey) {
+      lastTranslationMessageKeyRef.current = translationMessageKey;
+      setTranslationState({ status: "idle" });
+    }
+
+    return () => {
+      cancelActiveTranslation();
+    };
+  }, [cancelActiveTranslation, translationMessageKey]);
 
   const htmlContent = useMemo(
     () =>
@@ -476,71 +516,87 @@ export const MessageItem = memo((props: MessageItemProps) => {
   const handleTranslateMessage = useCallback(async () => {
     if (!messageContent.trim()) return;
 
-    const targetLanguage = getPreferredTranslationTargetLanguageFromSetting(
-      translationTargetLanguage,
-    );
-    const sourceLanguage =
-      getMessageSourceLanguage(message.tags) ??
-      (await detectMessageSourceLanguage({ text: messageContent }));
+    const { controller, runId } = beginTranslationRun();
+    const { signal } = controller;
+    const commitTranslationState = (nextState: TranslationState) => {
+      if (!isActiveTranslationRun(runId, signal)) return false;
 
-    if (!sourceLanguage) {
-      setTranslationState({
-        status: "error",
-        targetLanguage,
-        message: "Could not determine the message language for translation.",
-      });
-      return;
-    }
-
-    if (sourceLanguage === targetLanguage) {
-      setTranslationState({
-        status: "error",
-        targetLanguage,
-        message: "Message already matches your preferred language.",
-      });
-      return;
-    }
-
-    const availability = await getBrowserTranslationAvailability({
-      sourceLanguage,
-      targetLanguage,
-    });
-
-    if (
-      availability === "unsupported" ||
-      availability === "insecure-context" ||
-      availability === "unavailable"
-    ) {
-      const errorMessage =
-        availability === "unsupported"
-          ? "Translation is not supported in this browser."
-          : availability === "insecure-context"
-            ? "Translation requires a secure context."
-            : "This language pair is unavailable.";
-      setTranslationState({
-        status: "error",
-        targetLanguage,
-        message: errorMessage,
-      });
-      return;
-    }
-
-    setTranslationState(
-      availability === "available"
-        ? { status: "translating", targetLanguage }
-        : { status: "downloading", progress: 0, targetLanguage },
-    );
+      setTranslationState(nextState);
+      return true;
+    };
 
     try {
+      const targetLanguage = getPreferredTranslationTargetLanguageFromSetting(
+        translationTargetLanguage,
+      );
+      const sourceLanguage =
+        getMessageSourceLanguage(message.tags) ??
+        (await detectMessageSourceLanguage({ text: messageContent, signal }));
+
+      if (!sourceLanguage) {
+        commitTranslationState({
+          status: "error",
+          targetLanguage,
+          message: "Could not determine the message language for translation.",
+        });
+        return;
+      }
+
+      if (sourceLanguage === targetLanguage) {
+        commitTranslationState({
+          status: "error",
+          targetLanguage,
+          message: "Message already matches your preferred language.",
+        });
+        return;
+      }
+
+      const availability = await getBrowserTranslationAvailability({
+        sourceLanguage,
+        targetLanguage,
+      });
+
+      if (!isActiveTranslationRun(runId, signal)) return;
+
+      if (
+        availability === "unsupported" ||
+        availability === "insecure-context" ||
+        availability === "unavailable"
+      ) {
+        const errorMessage =
+          availability === "unsupported"
+            ? "Translation is not supported in this browser."
+            : availability === "insecure-context"
+              ? "Translation requires a secure context."
+              : "This language pair is unavailable.";
+        commitTranslationState({
+          status: "error",
+          targetLanguage,
+          message: errorMessage,
+        });
+        return;
+      }
+
+      if (
+        !commitTranslationState(
+          availability === "available"
+            ? { status: "translating", targetLanguage }
+            : { status: "downloading", progress: 0, targetLanguage },
+        )
+      ) {
+        return;
+      }
+
       const translatedText = await translateWithBrowser({
         sourceLanguage,
         targetLanguage,
         text: messageContent,
+        signal,
         onDownloadProgress:
           availability === "available"
             ? undefined
             : (progress) => {
-                setTranslationState({
+                commitTranslationState({
                   status: "downloading",
                   progress,
                   targetLanguage,
@@ -548,7 +604,11 @@ export const MessageItem = memo((props: MessageItemProps) => {
               },
       });
 
+      if (!isActiveTranslationRun(runId, signal)) return;
+
       startTransition(() => {
+        if (!isActiveTranslationRun(runId, signal)) return;
+
         setTranslationState({
           status: "translated",
           targetLanguage,
@@ -556,15 +616,29 @@ export const MessageItem = memo((props: MessageItemProps) => {
         });
       });
     } catch (error) {
+      if (!isActiveTranslationRun(runId, signal)) return;
+      if (signal.aborted) return;
+      if (error instanceof Error && error.name === "AbortError") return;
+
       const errorMessage =
         error instanceof Error ? error.message : "Translation failed.";
-      setTranslationState({
+      commitTranslationState({
         status: "error",
         targetLanguage,
         message: errorMessage,
       });
+    } finally {
+      if (isActiveTranslationRun(runId, signal)) {
+        activeTranslationAbortRef.current = null;
+      }
     }
-  }, [message.tags, messageContent, translationTargetLanguage]);
+  }, [
+    beginTranslationRun,
+    isActiveTranslationRun,
+    message.tags,
+    messageContent,
+    translationTargetLanguage,
+  ]);
 
   // Handle system messages
   if (isSystem) {

--- a/src/components/message/MessageItem.tsx
+++ b/src/components/message/MessageItem.tsx
@@ -1,7 +1,21 @@
 import type * as React from "react";
-import { memo, useCallback, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  startTransition,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useLongPress } from "../../hooks/useLongPress";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
+import {
+  canUseBrowserTranslation,
+  getBrowserTranslationAvailability,
+  getMessageSourceLanguage,
+  getPreferredTranslationTargetLanguageFromSetting,
+  translateWithBrowser,
+} from "../../lib/browserTranslation";
 import ircClient from "../../lib/ircClient";
 import {
   isUrlFromFilehost,
@@ -127,6 +141,13 @@ export function partitionMediaEntries(entries: MediaEntry[]) {
   return { extraNullEntries, firstKnownNotAtZero, extraKnownEntries };
 }
 
+type TranslationState =
+  | { status: "idle" }
+  | { status: "downloading"; progress: number; targetLanguage: string }
+  | { status: "translating"; targetLanguage: string }
+  | { status: "translated"; targetLanguage: string; text: string }
+  | { status: "error"; targetLanguage: string; message: string };
+
 // Theme is set once at startup and does not change while the app is running.
 // Reading it per-render via localStorage.getItem is unnecessary synchronous I/O.
 const CURRENT_THEME = localStorage.getItem("theme") || "discord";
@@ -161,6 +182,9 @@ export const MessageItem = memo((props: MessageItemProps) => {
   const [messageNeedsCollapsing, setMessageNeedsCollapsing] = useState(false);
   const messageRowRef = useRef<HTMLDivElement>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [translationState, setTranslationState] = useState<TranslationState>({
+    status: "idle",
+  });
   const longPress = useLongPress({
     onLongPress: () => setSheetOpen(true),
   });
@@ -168,22 +192,19 @@ export const MessageItem = memo((props: MessageItemProps) => {
   const handleMessageMouseEnter = () => {
     const el = messageRowRef.current;
     if (!el) return;
-    const msgRect = el.getBoundingClientRect();
-    // Toolbar: bottom-1 (4px from bottom), right-4 (16px from right), ~90px wide, ~32px tall
-    const toolbarTop = msgRect.bottom - 4 - 32;
-    const toolbarLeft = msgRect.right - 16 - 90;
-    const toolbarRight = msgRect.right - 16;
-    const toolbarBottom = msgRect.bottom - 4;
+    const toolbar = el.querySelector<HTMLElement>(".message-actions-container");
+    if (!toolbar) return;
+    const toolbarRect = toolbar.getBoundingClientRect();
 
     for (const btn of el.querySelectorAll<HTMLElement>(
       ".copy-button, .inline-copy-button",
     )) {
       const r = btn.getBoundingClientRect();
       const overlaps =
-        r.right > toolbarLeft &&
-        r.left < toolbarRight &&
-        r.bottom > toolbarTop &&
-        r.top < toolbarBottom;
+        r.right > toolbarRect.left &&
+        r.left < toolbarRect.right &&
+        r.bottom > toolbarRect.top &&
+        r.top < toolbarRect.bottom;
       if (overlaps) btn.classList.add("avoid-toolbar");
     }
   };
@@ -336,6 +357,9 @@ export const MessageItem = memo((props: MessageItemProps) => {
   const enableMarkdownRendering = useStore(
     useCallback((state) => state.globalSettings.enableMarkdownRendering, []),
   );
+  const translationTargetLanguage = useStore(
+    useCallback((state) => state.globalSettings.translationTargetLanguage, []),
+  );
   const openMedia = useStore(useCallback((state) => state.openMedia, []));
   const canRedact =
     !isSystem &&
@@ -344,6 +368,8 @@ export const MessageItem = memo((props: MessageItemProps) => {
     !!server?.capabilities?.includes("draft/message-redaction") &&
     !!onRedactMessage;
   const canReply = !hideReply && message.type === "message";
+  const canTranslate =
+    canReply && !!message.content.trim() && canUseBrowserTranslation();
 
   // message.content is already combined for multiline messages by the IRC client
   const messageContent = message.content;
@@ -376,6 +402,22 @@ export const MessageItem = memo((props: MessageItemProps) => {
 
   const theme = CURRENT_THEME;
   const username = message.userId;
+  const translatedHtmlContent = useMemo(() => {
+    if (translationState.status !== "translated") return null;
+
+    return processMarkdownInText(
+      translationState.text,
+      showExternalContent,
+      enableMarkdownRendering,
+      `${message.id || message.msgid || "msg"}-translated`,
+    );
+  }, [
+    translationState,
+    showExternalContent,
+    enableMarkdownRendering,
+    message.id,
+    message.msgid,
+  ]);
 
   // Strip IRC formatting codes so URL/image detection works even when the URL
   // is wrapped in bold, italic, underline, strikethrough, or color codes.
@@ -429,6 +471,88 @@ export const MessageItem = memo((props: MessageItemProps) => {
           mediaChannelId ?? undefined,
         )
     : undefined;
+
+  const handleTranslateMessage = useCallback(async () => {
+    if (!messageContent.trim()) return;
+
+    const targetLanguage = getPreferredTranslationTargetLanguageFromSetting(
+      translationTargetLanguage,
+    );
+    const sourceLanguage = getMessageSourceLanguage(message.tags);
+
+    if (sourceLanguage === targetLanguage) {
+      setTranslationState({
+        status: "error",
+        targetLanguage,
+        message: "Message already matches your preferred language.",
+      });
+      return;
+    }
+
+    const availability = await getBrowserTranslationAvailability({
+      sourceLanguage,
+      targetLanguage,
+    });
+
+    if (
+      availability === "unsupported" ||
+      availability === "insecure-context" ||
+      availability === "unavailable"
+    ) {
+      const errorMessage =
+        availability === "unsupported"
+          ? "Translation is not supported in this browser."
+          : availability === "insecure-context"
+            ? "Translation requires a secure context."
+            : "This language pair is unavailable.";
+      setTranslationState({
+        status: "error",
+        targetLanguage,
+        message: errorMessage,
+      });
+      return;
+    }
+
+    setTranslationState(
+      availability === "available"
+        ? { status: "translating", targetLanguage }
+        : { status: "downloading", progress: 0, targetLanguage },
+    );
+
+    try {
+      const translatedText = await translateWithBrowser({
+        sourceLanguage,
+        targetLanguage,
+        text: messageContent,
+        onDownloadProgress:
+          availability === "available"
+            ? undefined
+            : (progress) => {
+                setTranslationState({
+                  status: "downloading",
+                  progress,
+                  targetLanguage,
+                });
+              },
+      });
+
+      startTransition(() => {
+        setTranslationState({
+          status: "translated",
+          targetLanguage,
+          text: translatedText,
+        });
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Translation failed.";
+      setTranslationState({
+        status: "error",
+        targetLanguage,
+        message: errorMessage,
+      });
+    }
+  }, [message.tags, messageContent, translationTargetLanguage]);
 
   // Handle system messages
   if (isSystem) {
@@ -842,6 +966,42 @@ export const MessageItem = memo((props: MessageItemProps) => {
                 messageContent={message.content}
               />
             )}
+
+            {translationState.status !== "idle" && (
+              <div className="mt-2 rounded-lg border border-sky-400/20 bg-sky-500/10 px-3 py-2 text-sm text-sky-50">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-sky-200/80">
+                  {translationState.status === "translated"
+                    ? `Translated to ${translationState.targetLanguage}`
+                    : translationState.status === "downloading"
+                      ? `Preparing translation model for ${translationState.targetLanguage}`
+                      : translationState.status === "translating"
+                        ? `Translating to ${translationState.targetLanguage}`
+                        : `Translation unavailable for ${translationState.targetLanguage}`}
+                </div>
+                {translationState.status === "translated" &&
+                  translatedHtmlContent && (
+                    <div className="mt-1 overflow-hidden break-words whitespace-pre-wrap">
+                      {translatedHtmlContent}
+                    </div>
+                  )}
+                {translationState.status === "downloading" && (
+                  <div className="mt-1 text-sky-100/80">
+                    Download progress:{" "}
+                    {Math.round(translationState.progress * 100)}%
+                  </div>
+                )}
+                {translationState.status === "translating" && (
+                  <div className="mt-1 text-sky-100/80">
+                    Working on a local translation.
+                  </div>
+                )}
+                {translationState.status === "error" && (
+                  <div className="mt-1 text-amber-100">
+                    {translationState.message}
+                  </div>
+                )}
+              </div>
+            )}
           </div>
 
           <ReactionsWithActions
@@ -850,13 +1010,19 @@ export const MessageItem = memo((props: MessageItemProps) => {
             onReactionClick={handleReactionClick}
             onReactClick={(el) => onReactClick(message, el)}
             onReplyClick={() => setReplyTo(message)}
+            onTranslateClick={handleTranslateMessage}
             onRedactClick={
               canRedact ? () => onRedactMessage?.(message) : undefined
             }
             canRedact={canRedact}
             canReply={canReply}
+            canTranslate={canTranslate}
             onOpenMedia={handleOpenMedia}
             canOpenMedia={canOpenMedia}
+            isTranslating={
+              translationState.status === "downloading" ||
+              translationState.status === "translating"
+            }
           />
         </div>
       </div>
@@ -878,6 +1044,7 @@ export const MessageItem = memo((props: MessageItemProps) => {
               ? (el: Element) => onReactClick(message, el)
               : undefined
           }
+          onTranslate={canTranslate ? handleTranslateMessage : undefined}
           onDelete={
             canRedact
               ? () => {
@@ -896,8 +1063,13 @@ export const MessageItem = memo((props: MessageItemProps) => {
           }
           canReply={canReply}
           canReact={!!message.msgid}
+          canTranslate={canTranslate}
           canDelete={canRedact}
           canOpenMedia={canOpenMedia}
+          isTranslating={
+            translationState.status === "downloading" ||
+            translationState.status === "translating"
+          }
         />
       )}
     </div>

--- a/src/components/message/ReactionsWithActions.tsx
+++ b/src/components/message/ReactionsWithActions.tsx
@@ -10,11 +10,14 @@ interface ReactionsWithActionsProps {
   onReactionClick: (emoji: string, currentUserReacted: boolean) => void;
   onReactClick: (buttonElement: Element) => void;
   onReplyClick: () => void;
+  onTranslateClick?: () => void;
   onRedactClick?: () => void;
   onOpenMedia?: () => void;
   canRedact?: boolean;
   canReply?: boolean;
+  canTranslate?: boolean;
   canOpenMedia?: boolean;
+  isTranslating?: boolean;
 }
 
 export const ReactionsWithActions: React.FC<ReactionsWithActionsProps> = ({
@@ -23,11 +26,14 @@ export const ReactionsWithActions: React.FC<ReactionsWithActionsProps> = ({
   onReactionClick,
   onReactClick,
   onReplyClick,
+  onTranslateClick,
   onRedactClick,
   onOpenMedia,
   canRedact = false,
   canReply = true,
+  canTranslate = false,
   canOpenMedia = false,
+  isTranslating = false,
 }) => {
   const isTouchDevice = useMediaQuery("(pointer: coarse)");
   const hasReactions = !!message.reactions?.length;
@@ -47,11 +53,14 @@ export const ReactionsWithActions: React.FC<ReactionsWithActionsProps> = ({
           message={message}
           onReplyClick={onReplyClick}
           onReactClick={onReactClick}
+          onTranslateClick={onTranslateClick}
           onRedactClick={onRedactClick}
           onOpenMedia={onOpenMedia}
           canRedact={canRedact}
           canReply={canReply}
+          canTranslate={canTranslate}
           canOpenMedia={canOpenMedia}
+          isTranslating={isTranslating}
           inline
         />
       </div>
@@ -71,11 +80,14 @@ export const ReactionsWithActions: React.FC<ReactionsWithActionsProps> = ({
           message={message}
           onReplyClick={onReplyClick}
           onReactClick={onReactClick}
+          onTranslateClick={onTranslateClick}
           onRedactClick={onRedactClick}
           onOpenMedia={onOpenMedia}
           canRedact={canRedact}
           canReply={canReply}
+          canTranslate={canTranslate}
           canOpenMedia={canOpenMedia}
+          isTranslating={isTranslating}
         />
       )}
     </>

--- a/src/components/mobile/MessageBottomSheet.tsx
+++ b/src/components/mobile/MessageBottomSheet.tsx
@@ -44,6 +44,7 @@ const MessageBottomSheet: React.FC<MessageBottomSheetProps> = ({
     icon: React.ReactNode;
     onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
     className?: string;
+    disabled?: boolean;
   }[] = [];
 
   if (canReply && onReply) {
@@ -73,10 +74,12 @@ const MessageBottomSheet: React.FC<MessageBottomSheetProps> = ({
       label: isTranslating ? "Translating" : "Translate",
       icon: <FaLanguage />,
       onClick: () => {
+        if (isTranslating) return;
         onTranslate();
         onClose();
       },
       className: isTranslating ? "text-sky-300/70" : undefined,
+      disabled: isTranslating,
     });
   }
 
@@ -114,6 +117,7 @@ const MessageBottomSheet: React.FC<MessageBottomSheetProps> = ({
             className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg active:bg-discord-dark-400 text-left ${action.className || "text-white"}`}
             style={{ minHeight: "48px" }}
             onClick={action.onClick}
+            disabled={action.disabled}
           >
             <span className="text-lg">{action.icon}</span>
             <span className="text-sm font-medium">{action.label}</span>

--- a/src/components/mobile/MessageBottomSheet.tsx
+++ b/src/components/mobile/MessageBottomSheet.tsx
@@ -1,5 +1,11 @@
 import type React from "react";
-import { FaExpand, FaGrinAlt, FaReply, FaTimes } from "react-icons/fa";
+import {
+  FaExpand,
+  FaGrinAlt,
+  FaLanguage,
+  FaReply,
+  FaTimes,
+} from "react-icons/fa";
 import BottomSheet from "./BottomSheet";
 
 interface MessageBottomSheetProps {
@@ -7,12 +13,15 @@ interface MessageBottomSheetProps {
   onClose: () => void;
   onReply?: () => void;
   onReact?: (buttonElement: Element) => void;
+  onTranslate?: () => void;
   onDelete?: () => void;
   onOpenMedia?: () => void;
   canReply: boolean;
   canReact: boolean;
+  canTranslate: boolean;
   canDelete: boolean;
   canOpenMedia?: boolean;
+  isTranslating?: boolean;
 }
 
 const MessageBottomSheet: React.FC<MessageBottomSheetProps> = ({
@@ -20,12 +29,15 @@ const MessageBottomSheet: React.FC<MessageBottomSheetProps> = ({
   onClose,
   onReply,
   onReact,
+  onTranslate,
   onDelete,
   onOpenMedia,
   canReply,
   canReact,
+  canTranslate,
   canDelete,
   canOpenMedia = false,
+  isTranslating = false,
 }) => {
   const actions: {
     label: string;
@@ -53,6 +65,18 @@ const MessageBottomSheet: React.FC<MessageBottomSheetProps> = ({
         onReact(e.currentTarget);
         onClose();
       },
+    });
+  }
+
+  if (canTranslate && onTranslate) {
+    actions.push({
+      label: isTranslating ? "Translating" : "Translate",
+      icon: <FaLanguage />,
+      onClick: () => {
+        onTranslate();
+        onClose();
+      },
+      className: isTranslating ? "text-sky-300/70" : undefined,
     });
   }
 

--- a/src/lib/browserTranslation.ts
+++ b/src/lib/browserTranslation.ts
@@ -20,51 +20,10 @@ export interface BrowserTranslationRequest extends TranslationLanguagePair {
   onDownloadProgress?: (progress: number) => void;
 }
 
-export function normalizeTranslationLanguageTag(
-  language: string | null | undefined,
-): string | null {
-  const trimmed = language?.trim();
-  if (!trimmed) return null;
-
-  const [primarySubtag] = trimmed.split("-");
-  const normalized = primarySubtag?.toLowerCase();
-  return normalized || null;
-}
-
-export function getPreferredTranslationTargetLanguage(): string {
-  return getPreferredTranslationTargetLanguageFromSetting();
-}
-
-export function getPreferredTranslationTargetLanguageFromSetting(
-  explicitLanguage?: string | null,
-): string {
-  const explicit = normalizeTranslationLanguageTag(explicitLanguage);
-  if (explicit) return explicit;
-
-  const languages =
-    typeof navigator === "undefined"
-      ? []
-      : [navigator.language, ...(navigator.languages ?? [])];
-
-  for (const language of languages) {
-    const normalized = normalizeTranslationLanguageTag(language);
-    if (normalized) return normalized;
-  }
-
-  return "en";
-}
-
-export function getMessageSourceLanguage(
-  tags?: Record<string, string>,
-): string {
-  return (
-    normalizeTranslationLanguageTag(
-      tags?.["+draft/language"] ??
-        tags?.["draft/language"] ??
-        tags?.["+language"] ??
-        tags?.language,
-    ) ?? "en"
-  );
+export interface BrowserLanguageDetectionRequest {
+  text: string;
+  signal?: AbortSignal;
+  onDownloadProgress?: (progress: number) => void;
 }
 
 interface CreateMonitorLike {
@@ -72,6 +31,22 @@ interface CreateMonitorLike {
     type: "downloadprogress",
     listener: (event: Event) => void,
   ): void;
+}
+
+interface BrowserLanguageDetectionResult {
+  detectedLanguage?: string;
+}
+
+interface BrowserLanguageDetectorInstance {
+  detect(input: string): Promise<BrowserLanguageDetectionResult[]>;
+  destroy(): void;
+}
+
+interface BrowserLanguageDetectorStatic {
+  create(options?: {
+    signal?: AbortSignal;
+    monitor?: (monitor: CreateMonitorLike) => void;
+  }): Promise<BrowserLanguageDetectorInstance>;
 }
 
 interface BrowserTranslatorInstance {
@@ -91,6 +66,15 @@ interface BrowserTranslatorStatic {
   }): Promise<BrowserTranslatorInstance>;
 }
 
+function getLanguageDetectorApi(): BrowserLanguageDetectorStatic | null {
+  const maybeLanguageDetector = (
+    globalThis as typeof globalThis & {
+      LanguageDetector?: BrowserLanguageDetectorStatic;
+    }
+  ).LanguageDetector;
+  return maybeLanguageDetector ?? null;
+}
+
 function getTranslatorApi(): BrowserTranslatorStatic | null {
   const maybeTranslator = (
     globalThis as typeof globalThis & {
@@ -100,10 +84,108 @@ function getTranslatorApi(): BrowserTranslatorStatic | null {
   return maybeTranslator ?? null;
 }
 
+/**
+ * Canonicalizes a BCP 47 language tag without discarding script or region subtags.
+ */
+export function normalizeTranslationLanguageTag(
+  language: string | null | undefined,
+): string | null {
+  const trimmed = language?.trim();
+  if (!trimmed) return null;
+
+  try {
+    return Intl.getCanonicalLocales(trimmed)[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolves the preferred target language, falling back to the browser locale.
+ */
+export function getPreferredTranslationTargetLanguage(): string {
+  return getPreferredTranslationTargetLanguageFromSetting();
+}
+
+/**
+ * Resolves the preferred target language using an explicit setting when present.
+ */
+export function getPreferredTranslationTargetLanguageFromSetting(
+  explicitLanguage?: string | null,
+): string {
+  const explicit = normalizeTranslationLanguageTag(explicitLanguage);
+  if (explicit) return explicit;
+
+  const languages =
+    typeof navigator === "undefined"
+      ? []
+      : [navigator.language, ...(navigator.languages ?? [])];
+
+  for (const language of languages) {
+    const normalized = normalizeTranslationLanguageTag(language);
+    if (normalized) return normalized;
+  }
+
+  return "en";
+}
+
+/**
+ * Reads the source language from IRC message metadata when one is available.
+ */
+export function getMessageSourceLanguage(
+  tags?: Record<string, string>,
+): string | null {
+  return normalizeTranslationLanguageTag(
+    tags?.["+draft/language"] ??
+      tags?.["draft/language"] ??
+      tags?.["+language"] ??
+      tags?.language,
+  );
+}
+
 export function canUseBrowserTranslation(): boolean {
   return window.isSecureContext && getTranslatorApi() !== null;
 }
 
+/**
+ * Detects the source language for untagged messages using the browser detector API.
+ */
+export async function detectMessageSourceLanguage({
+  text,
+  signal,
+  onDownloadProgress,
+}: BrowserLanguageDetectionRequest): Promise<string | null> {
+  if (!window.isSecureContext) return null;
+
+  const languageDetectorApi = getLanguageDetectorApi();
+  if (!languageDetectorApi) return null;
+
+  try {
+    const detector = await languageDetectorApi.create({
+      signal,
+      monitor: onDownloadProgress
+        ? (monitor) => {
+            monitor.addEventListener("downloadprogress", (event) => {
+              onDownloadProgress((event as ProgressEvent).loaded);
+            });
+          }
+        : undefined,
+    });
+
+    try {
+      const results = await detector.detect(text);
+      return normalizeTranslationLanguageTag(results[0]?.detectedLanguage);
+    } finally {
+      detector.destroy();
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Checks whether the runtime supports a requested translation pair.
+ */
 export async function getBrowserTranslationAvailability({
   sourceLanguage,
   targetLanguage,
@@ -127,6 +209,9 @@ export async function getBrowserTranslationAvailability({
   }
 }
 
+/**
+ * Creates a translator, runs a translation, and disposes the translator instance.
+ */
 export async function translateWithBrowser({
   sourceLanguage,
   targetLanguage,

--- a/src/lib/browserTranslation.ts
+++ b/src/lib/browserTranslation.ts
@@ -1,0 +1,164 @@
+export type NativeTranslatorAvailability =
+  | "available"
+  | "downloadable"
+  | "downloading"
+  | "unavailable";
+
+export type BrowserTranslationAvailability =
+  | NativeTranslatorAvailability
+  | "unsupported"
+  | "insecure-context";
+
+export interface TranslationLanguagePair {
+  sourceLanguage: string;
+  targetLanguage: string;
+}
+
+export interface BrowserTranslationRequest extends TranslationLanguagePair {
+  text: string;
+  signal?: AbortSignal;
+  onDownloadProgress?: (progress: number) => void;
+}
+
+export function normalizeTranslationLanguageTag(
+  language: string | null | undefined,
+): string | null {
+  const trimmed = language?.trim();
+  if (!trimmed) return null;
+
+  const [primarySubtag] = trimmed.split("-");
+  const normalized = primarySubtag?.toLowerCase();
+  return normalized || null;
+}
+
+export function getPreferredTranslationTargetLanguage(): string {
+  return getPreferredTranslationTargetLanguageFromSetting();
+}
+
+export function getPreferredTranslationTargetLanguageFromSetting(
+  explicitLanguage?: string | null,
+): string {
+  const explicit = normalizeTranslationLanguageTag(explicitLanguage);
+  if (explicit) return explicit;
+
+  const languages =
+    typeof navigator === "undefined"
+      ? []
+      : [navigator.language, ...(navigator.languages ?? [])];
+
+  for (const language of languages) {
+    const normalized = normalizeTranslationLanguageTag(language);
+    if (normalized) return normalized;
+  }
+
+  return "en";
+}
+
+export function getMessageSourceLanguage(
+  tags?: Record<string, string>,
+): string {
+  return (
+    normalizeTranslationLanguageTag(
+      tags?.["+draft/language"] ??
+        tags?.["draft/language"] ??
+        tags?.["+language"] ??
+        tags?.language,
+    ) ?? "en"
+  );
+}
+
+interface CreateMonitorLike {
+  addEventListener(
+    type: "downloadprogress",
+    listener: (event: Event) => void,
+  ): void;
+}
+
+interface BrowserTranslatorInstance {
+  translate(input: string, options?: { signal?: AbortSignal }): Promise<string>;
+  destroy(): void;
+}
+
+interface BrowserTranslatorStatic {
+  availability(
+    options: TranslationLanguagePair,
+  ): Promise<NativeTranslatorAvailability | null>;
+  create(options: {
+    sourceLanguage: string;
+    targetLanguage: string;
+    signal?: AbortSignal;
+    monitor?: (monitor: CreateMonitorLike) => void;
+  }): Promise<BrowserTranslatorInstance>;
+}
+
+function getTranslatorApi(): BrowserTranslatorStatic | null {
+  const maybeTranslator = (
+    globalThis as typeof globalThis & {
+      Translator?: BrowserTranslatorStatic;
+    }
+  ).Translator;
+  return maybeTranslator ?? null;
+}
+
+export function canUseBrowserTranslation(): boolean {
+  return window.isSecureContext && getTranslatorApi() !== null;
+}
+
+export async function getBrowserTranslationAvailability({
+  sourceLanguage,
+  targetLanguage,
+}: TranslationLanguagePair): Promise<BrowserTranslationAvailability> {
+  if (!window.isSecureContext) return "insecure-context";
+
+  const translatorApi = getTranslatorApi();
+  if (!translatorApi) return "unsupported";
+
+  if (sourceLanguage === targetLanguage) return "unavailable";
+
+  try {
+    return (
+      (await translatorApi.availability({
+        sourceLanguage,
+        targetLanguage,
+      })) ?? "unavailable"
+    );
+  } catch {
+    return "unavailable";
+  }
+}
+
+export async function translateWithBrowser({
+  sourceLanguage,
+  targetLanguage,
+  text,
+  signal,
+  onDownloadProgress,
+}: BrowserTranslationRequest): Promise<string> {
+  if (!window.isSecureContext) {
+    throw new Error("Browser translation requires a secure context.");
+  }
+
+  const translatorApi = getTranslatorApi();
+  if (!translatorApi) {
+    throw new Error("Browser translation is not supported in this runtime.");
+  }
+
+  const translator = await translatorApi.create({
+    sourceLanguage,
+    targetLanguage,
+    signal,
+    monitor: onDownloadProgress
+      ? (monitor) => {
+          monitor.addEventListener("downloadprogress", (event) => {
+            onDownloadProgress((event as ProgressEvent).loaded);
+          });
+        }
+      : undefined,
+  });
+
+  try {
+    return await translator.translate(text, { signal });
+  } finally {
+    translator.destroy();
+  }
+}

--- a/src/lib/browserTranslation.ts
+++ b/src/lib/browserTranslation.ts
@@ -35,7 +35,11 @@ interface CreateMonitorLike {
 
 interface BrowserLanguageDetectionResult {
   detectedLanguage?: string;
+  confidence?: number;
 }
+
+const MIN_BROWSER_LANGUAGE_DETECTION_TEXT_LENGTH = 20;
+const MIN_BROWSER_LANGUAGE_DETECTION_CONFIDENCE = 0.5;
 
 interface BrowserLanguageDetectorInstance {
   detect(input: string): Promise<BrowserLanguageDetectionResult[]>;
@@ -156,6 +160,9 @@ export async function detectMessageSourceLanguage({
   onDownloadProgress,
 }: BrowserLanguageDetectionRequest): Promise<string | null> {
   if (!window.isSecureContext) return null;
+  if (text.trim().length < MIN_BROWSER_LANGUAGE_DETECTION_TEXT_LENGTH) {
+    return null;
+  }
 
   const languageDetectorApi = getLanguageDetectorApi();
   if (!languageDetectorApi) return null;
@@ -174,7 +181,24 @@ export async function detectMessageSourceLanguage({
 
     try {
       const results = await detector.detect(text);
-      return normalizeTranslationLanguageTag(results[0]?.detectedLanguage);
+
+      for (const result of results) {
+        const normalizedLanguage = normalizeTranslationLanguageTag(
+          result.detectedLanguage,
+        );
+
+        if (!normalizedLanguage || normalizedLanguage === "und") continue;
+        if (
+          typeof result.confidence === "number" &&
+          result.confidence < MIN_BROWSER_LANGUAGE_DETECTION_CONFIDENCE
+        ) {
+          continue;
+        }
+
+        return normalizedLanguage;
+      }
+
+      return null;
     } finally {
       detector.destroy();
     }

--- a/src/lib/settings/definitions/allSettings.ts
+++ b/src/lib/settings/definitions/allSettings.ts
@@ -250,6 +250,20 @@ const preferenceSettings: SettingDefinition[] = [
     priority: 2,
   },
   {
+    id: "preferences.translationTargetLanguage",
+    key: "translationTargetLanguage",
+    category: "preferences",
+    subcategory: "Chat",
+    title: "Translation Target Language",
+    description:
+      "Preferred translation target language as a BCP 47 tag. Leave empty to use your browser language.",
+    type: "text",
+    defaultValue: "",
+    placeholder: "e.g. en, es, ja",
+    searchKeywords: ["translate", "translation", "language", "locale"],
+    priority: 3,
+  },
+  {
     id: "preferences.showEvents",
     key: "showEvents",
     category: "preferences",
@@ -259,7 +273,7 @@ const preferenceSettings: SettingDefinition[] = [
     type: "toggle",
     defaultValue: true,
     searchKeywords: ["events", "messages", "activity"],
-    priority: 3,
+    priority: 4,
   },
   {
     id: "preferences.showNickChanges",
@@ -271,7 +285,7 @@ const preferenceSettings: SettingDefinition[] = [
     type: "toggle",
     defaultValue: true,
     searchKeywords: ["nick", "change", "rename"],
-    priority: 4,
+    priority: 5,
     dependencies: [
       {
         settingId: "preferences.showEvents",
@@ -289,7 +303,7 @@ const preferenceSettings: SettingDefinition[] = [
     type: "toggle",
     defaultValue: true,
     searchKeywords: ["join", "part", "leave", "enter"],
-    priority: 5,
+    priority: 6,
     dependencies: [
       {
         settingId: "preferences.showEvents",
@@ -307,7 +321,7 @@ const preferenceSettings: SettingDefinition[] = [
     type: "toggle",
     defaultValue: true,
     searchKeywords: ["quit", "disconnect", "leave"],
-    priority: 6,
+    priority: 7,
     dependencies: [
       {
         settingId: "preferences.showEvents",
@@ -325,7 +339,7 @@ const preferenceSettings: SettingDefinition[] = [
     type: "toggle",
     defaultValue: true,
     searchKeywords: ["kick", "ban", "remove"],
-    priority: 7,
+    priority: 8,
     dependencies: [
       {
         settingId: "preferences.showEvents",
@@ -343,7 +357,7 @@ const preferenceSettings: SettingDefinition[] = [
     type: "toggle",
     defaultValue: true,
     searchKeywords: ["multiline", "input", "text", "enter"],
-    priority: 8,
+    priority: 9,
   },
   {
     id: "preferences.multilineShiftEnter",
@@ -355,7 +369,7 @@ const preferenceSettings: SettingDefinition[] = [
     type: "toggle",
     defaultValue: true,
     searchKeywords: ["shift", "enter", "multiline", "keyboard"],
-    priority: 9,
+    priority: 10,
     dependencies: [
       {
         settingId: "preferences.multilineInput",
@@ -373,7 +387,7 @@ const preferenceSettings: SettingDefinition[] = [
     type: "toggle",
     defaultValue: false,
     searchKeywords: ["fallback", "single", "line", "auto"],
-    priority: 10,
+    priority: 11,
     dependencies: [
       {
         settingId: "preferences.multilineInput",
@@ -391,7 +405,7 @@ const preferenceSettings: SettingDefinition[] = [
     type: "custom",
     defaultValue: [],
     searchKeywords: ["ignore", "block", "mute", "filter"],
-    priority: 11,
+    priority: 12,
     customComponent: IgnoreListField,
   },
 ];

--- a/src/lib/settings/definitions/allSettings.ts
+++ b/src/lib/settings/definitions/allSettings.ts
@@ -260,6 +260,18 @@ const preferenceSettings: SettingDefinition[] = [
     type: "text",
     defaultValue: "",
     placeholder: "e.g. en, es, ja",
+    validation: {
+      custom: (value) => {
+        const text = String(value).trim();
+        if (!text) return true;
+
+        try {
+          return Intl.getCanonicalLocales(text).length > 0;
+        } catch {
+          return "Enter a valid BCP 47 language tag such as en, es-MX, or zh-Hant.";
+        }
+      },
+    },
     searchKeywords: ["translate", "translation", "language", "locale"],
     priority: 3,
   },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -938,7 +938,6 @@ const useStore = create<AppState>((set, get) => ({
     mediaVisibilityLevel: 1 as MediaVisibilityLevel,
     // Markdown settings
     enableMarkdownRendering: false,
-    // Translation settings
     translationTargetLanguage: "",
     // Status messages
     awayMessage: "",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -938,6 +938,8 @@ const useStore = create<AppState>((set, get) => ({
     mediaVisibilityLevel: 1 as MediaVisibilityLevel,
     // Markdown settings
     enableMarkdownRendering: false,
+    // Translation settings
+    translationTargetLanguage: "",
     // Status messages
     awayMessage: "",
     quitMessage: "ObsidianIRC - Bringing IRC to the future",

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -52,6 +52,7 @@ export interface GlobalSettings {
   autoFallbackToSingleLine: boolean;
   mediaVisibilityLevel: MediaVisibilityLevel;
   enableMarkdownRendering: boolean;
+  translationTargetLanguage: string;
   awayMessage: string;
   quitMessage: string;
 }

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -62,6 +62,7 @@ const mockStoreState = {
     showNickChanges: true,
     showJoinsParts: true,
     showQuits: true,
+    translationTargetLanguage: "",
   },
   updateGlobalSettings: vi.fn(),
   metadataSet: vi.fn(),

--- a/tests/components/ChannelSettingsModal.test.tsx
+++ b/tests/components/ChannelSettingsModal.test.tsx
@@ -84,6 +84,7 @@ describe("ChannelSettingsModal", () => {
       enableNotifications: true,
       notificationSound: "default",
       notificationVolume: 0.8,
+      translationTargetLanguage: "",
     },
     ui: {
       selectedServerId: null,

--- a/tests/components/LinkSecurityWarningModal.test.tsx
+++ b/tests/components/LinkSecurityWarningModal.test.tsx
@@ -127,6 +127,7 @@ describe("LinkSecurityWarningModal", () => {
         notificationSound: "default",
         notificationVolume: 0.8,
         skipLinkSecurityWarnings: false,
+        translationTargetLanguage: "",
       },
     };
 

--- a/tests/components/MediaCommentsSidebar.test.tsx
+++ b/tests/components/MediaCommentsSidebar.test.tsx
@@ -53,7 +53,10 @@ vi.mock("../../src/store", () => ({
       const state = {
         servers: [{ id: "s1", channels: [mockChannel] }],
         messages: {},
-        globalSettings: { mediaVisibilityLevel: 3 },
+        globalSettings: {
+          mediaVisibilityLevel: 3,
+          translationTargetLanguage: "",
+        },
       };
       return selector(state);
     }),

--- a/tests/components/MessageActions.test.tsx
+++ b/tests/components/MessageActions.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { MessageActions } from "../../src/components/message/MessageActions";
+import type { MessageType } from "../../src/types";
+
+const baseMessage: MessageType = {
+  id: "msg-1",
+  type: "message",
+  content: "hello",
+  timestamp: new Date("2026-01-01T00:00:00Z"),
+  userId: "alice",
+  channelId: "channel-1",
+  serverId: "server-1",
+  reactions: [],
+  replyMessage: null,
+  mentioned: [],
+  msgid: "abc123",
+};
+
+describe("MessageActions", () => {
+  test("renders translate action when enabled", () => {
+    render(
+      <MessageActions
+        message={baseMessage}
+        onReplyClick={vi.fn()}
+        onReactClick={vi.fn()}
+        onTranslateClick={vi.fn()}
+        canTranslate
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /translate message/i }),
+    ).toBeInTheDocument();
+  });
+
+  test("calls translate handler when clicked", () => {
+    const onTranslateClick = vi.fn();
+
+    render(
+      <MessageActions
+        message={baseMessage}
+        onReplyClick={vi.fn()}
+        onReactClick={vi.fn()}
+        onTranslateClick={onTranslateClick}
+        canTranslate
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /translate message/i }));
+    expect(onTranslateClick).toHaveBeenCalledOnce();
+  });
+
+  test("disables translate action while translating", () => {
+    render(
+      <MessageActions
+        message={baseMessage}
+        onReplyClick={vi.fn()}
+        onReactClick={vi.fn()}
+        onTranslateClick={vi.fn()}
+        canTranslate
+        isTranslating
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /translating message/i }),
+    ).toBeDisabled();
+  });
+});

--- a/tests/components/MessageItem.translation.test.tsx
+++ b/tests/components/MessageItem.translation.test.tsx
@@ -141,6 +141,18 @@ vi.mock("../../src/components/message/index", async () => {
 import { MessageItem } from "../../src/components/message/MessageItem";
 import type { MessageType } from "../../src/types";
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
 const message: MessageType = {
   id: "msg-1",
   msgid: "abc123",
@@ -231,7 +243,9 @@ describe("MessageItem translation", () => {
     );
 
     await waitFor(() => {
-      expect(mockDetectLanguage).toHaveBeenCalledWith({ text: "hello world" });
+      expect(mockDetectLanguage).toHaveBeenCalledWith(
+        expect.objectContaining({ text: "hello world" }),
+      );
     });
     expect(mockTranslate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -239,5 +253,60 @@ describe("MessageItem translation", () => {
         targetLanguage: "pt-BR",
       }),
     );
+  });
+
+  test("ignores stale translation results when a newer request starts", async () => {
+    const firstTranslation = createDeferred<string>();
+    const secondTranslation = createDeferred<string>();
+
+    mockTranslate
+      .mockReturnValueOnce(firstTranslation.promise)
+      .mockReturnValueOnce(secondTranslation.promise);
+
+    render(
+      <MessageItem
+        message={message}
+        showDate={false}
+        showHeader={false}
+        setReplyTo={vi.fn()}
+        onUsernameContextMenu={vi.fn()}
+        onReactClick={vi.fn()}
+        onReactionUnreact={vi.fn()}
+        onOpenReactionModal={vi.fn()}
+        onDirectReaction={vi.fn()}
+        serverId="server-1"
+        channelId="channel-1"
+      />,
+    );
+
+    const translateButton = screen.getByRole("button", {
+      name: /translate from actions/i,
+    });
+
+    fireEvent.click(translateButton);
+
+    await waitFor(() => {
+      expect(mockTranslate).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(translateButton);
+
+    await waitFor(() => {
+      expect(mockTranslate).toHaveBeenCalledTimes(2);
+    });
+
+    firstTranslation.resolve("hola viejo");
+
+    await waitFor(() => {
+      expect(screen.queryByText("hola viejo")).not.toBeInTheDocument();
+    });
+
+    secondTranslation.resolve("hola nuevo");
+
+    await waitFor(() => {
+      expect(screen.getByText("hola nuevo")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("hola viejo")).not.toBeInTheDocument();
   });
 });

--- a/tests/components/MessageItem.translation.test.tsx
+++ b/tests/components/MessageItem.translation.test.tsx
@@ -1,0 +1,199 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockState = {
+  servers: [
+    {
+      id: "server-1",
+      channels: [{ id: "channel-1", users: [] }],
+      privateChats: [],
+      capabilities: [],
+      filehost: null,
+    },
+  ],
+  globalSettings: {
+    mediaVisibilityLevel: 1,
+    enableMarkdownRendering: false,
+    translationTargetLanguage: "es",
+  },
+  openMedia: vi.fn(),
+};
+
+const mockAvailability = vi.fn();
+const mockTranslate = vi.fn();
+const mockTargetLanguage = vi.fn();
+
+vi.mock("../../src/hooks/useLongPress", () => ({
+  useLongPress: () => ({
+    onTouchStart: vi.fn(),
+    onTouchMove: vi.fn(),
+    onTouchEnd: vi.fn(),
+    onTouchCancel: vi.fn(),
+  }),
+}));
+
+vi.mock("../../src/hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
+}));
+
+vi.mock("../../src/lib/browserTranslation", () => ({
+  canUseBrowserTranslation: () => true,
+  getBrowserTranslationAvailability: (...args: unknown[]) =>
+    mockAvailability(...args),
+  getMessageSourceLanguage: () => "en",
+  getPreferredTranslationTargetLanguageFromSetting: (...args: unknown[]) =>
+    mockTargetLanguage(...args),
+  translateWithBrowser: (...args: unknown[]) => mockTranslate(...args),
+}));
+
+vi.mock("../../src/lib/ircClient", () => ({
+  default: {
+    getCurrentUser: () => ({ username: "bob" }),
+  },
+}));
+
+vi.mock("../../src/lib/ircUtils", () => ({
+  isUrlFromFilehost: () => false,
+  isUserVerified: () => false,
+  processMarkdownInText: (content: string) => content,
+}));
+
+vi.mock("../../src/lib/mediaUtils", () => ({
+  canShowMedia: () => false,
+  extractMediaFromMessage: () => [],
+  mediaLevelToSettings: () => ({
+    showSafeMedia: true,
+    showTrustedSourcesMedia: false,
+    showExternalContent: false,
+  }),
+}));
+
+vi.mock("../../src/lib/messageFormatter", () => ({
+  stripIrcFormatting: (content: string) => content,
+}));
+
+vi.mock("../../src/store", () => {
+  const useStore = Object.assign(
+    (selector: (state: typeof mockState) => unknown) => selector(mockState),
+    { getState: () => mockState },
+  );
+
+  return {
+    __esModule: true,
+    default: useStore,
+    loadSavedMetadata: () => ({}),
+  };
+});
+
+vi.mock("../../src/components/mobile/MessageBottomSheet", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../src/components/ui/LinkWrapper", () => ({
+  EnhancedLinkWrapper: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("../../src/components/message/InviteMessage", () => ({
+  InviteMessage: () => null,
+}));
+
+vi.mock("../../src/components/message/MediaPreview", () => ({
+  MediaPreview: () => null,
+}));
+
+vi.mock("../../src/components/message/index", async () => {
+  const ReactModule = await import("react");
+
+  return {
+    ActionMessage: () => null,
+    CollapsibleMessage: ReactModule.forwardRef(
+      ({ content }: { content: React.ReactNode }, _ref) => <div>{content}</div>,
+    ),
+    DateSeparator: () => null,
+    EventMessage: () => null,
+    JsonLogMessage: () => null,
+    LinkPreview: () => null,
+    MessageAvatar: () => null,
+    MessageHeader: () => null,
+    MessageReply: () => null,
+    ReactionsWithActions: ({
+      onTranslateClick,
+    }: {
+      onTranslateClick?: () => void;
+    }) => (
+      <button type="button" onClick={onTranslateClick}>
+        Translate from actions
+      </button>
+    ),
+    StandardReplyNotification: () => null,
+    SystemMessage: () => null,
+    WhisperMessage: () => null,
+  };
+});
+
+import { MessageItem } from "../../src/components/message/MessageItem";
+import type { MessageType } from "../../src/types";
+
+const message: MessageType = {
+  id: "msg-1",
+  msgid: "abc123",
+  type: "message",
+  content: "hello world",
+  timestamp: new Date("2026-04-22T12:00:00Z"),
+  userId: "alice",
+  channelId: "channel-1",
+  serverId: "server-1",
+  reactions: [],
+  replyMessage: null,
+  mentioned: [],
+};
+
+describe("MessageItem translation", () => {
+  beforeEach(() => {
+    mockAvailability.mockReset();
+    mockTranslate.mockReset();
+    mockTargetLanguage.mockReset();
+    mockState.globalSettings.translationTargetLanguage = "es";
+    mockAvailability.mockResolvedValue("available");
+    mockTranslate.mockResolvedValue("hola mundo");
+    mockTargetLanguage.mockReturnValue("es");
+  });
+
+  test("uses the explicit target language setting and renders translated output", async () => {
+    render(
+      <MessageItem
+        message={message}
+        showDate={false}
+        showHeader={false}
+        setReplyTo={vi.fn()}
+        onUsernameContextMenu={vi.fn()}
+        onReactClick={vi.fn()}
+        onReactionUnreact={vi.fn()}
+        onOpenReactionModal={vi.fn()}
+        onDirectReaction={vi.fn()}
+        serverId="server-1"
+        channelId="channel-1"
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /translate from actions/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("hola mundo")).toBeInTheDocument();
+    });
+
+    expect(mockTargetLanguage).toHaveBeenCalledWith("es");
+    expect(mockTranslate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceLanguage: "en",
+        targetLanguage: "es",
+        text: "hello world",
+      }),
+    );
+  });
+});

--- a/tests/components/MessageItem.translation.test.tsx
+++ b/tests/components/MessageItem.translation.test.tsx
@@ -21,6 +21,8 @@ const mockState = {
 };
 
 const mockAvailability = vi.fn();
+const mockDetectLanguage = vi.fn();
+const mockSourceLanguage = vi.fn();
 const mockTranslate = vi.fn();
 const mockTargetLanguage = vi.fn();
 
@@ -39,9 +41,11 @@ vi.mock("../../src/hooks/useMediaQuery", () => ({
 
 vi.mock("../../src/lib/browserTranslation", () => ({
   canUseBrowserTranslation: () => true,
+  detectMessageSourceLanguage: (...args: unknown[]) =>
+    mockDetectLanguage(...args),
   getBrowserTranslationAvailability: (...args: unknown[]) =>
     mockAvailability(...args),
-  getMessageSourceLanguage: () => "en",
+  getMessageSourceLanguage: (...args: unknown[]) => mockSourceLanguage(...args),
   getPreferredTranslationTargetLanguageFromSetting: (...args: unknown[]) =>
     mockTargetLanguage(...args),
   translateWithBrowser: (...args: unknown[]) => mockTranslate(...args),
@@ -154,10 +158,14 @@ const message: MessageType = {
 describe("MessageItem translation", () => {
   beforeEach(() => {
     mockAvailability.mockReset();
+    mockDetectLanguage.mockReset();
+    mockSourceLanguage.mockReset();
     mockTranslate.mockReset();
     mockTargetLanguage.mockReset();
     mockState.globalSettings.translationTargetLanguage = "es";
     mockAvailability.mockResolvedValue("available");
+    mockDetectLanguage.mockResolvedValue("fr-CA");
+    mockSourceLanguage.mockReturnValue("en");
     mockTranslate.mockResolvedValue("hola mundo");
     mockTargetLanguage.mockReturnValue("es");
   });
@@ -193,6 +201,42 @@ describe("MessageItem translation", () => {
         sourceLanguage: "en",
         targetLanguage: "es",
         text: "hello world",
+      }),
+    );
+  });
+
+  test("detects the source language when the message has no language tag", async () => {
+    mockState.globalSettings.translationTargetLanguage = "";
+    mockSourceLanguage.mockReturnValue(null);
+    mockTargetLanguage.mockReturnValue("pt-BR");
+
+    render(
+      <MessageItem
+        message={message}
+        showDate={false}
+        showHeader={false}
+        setReplyTo={vi.fn()}
+        onUsernameContextMenu={vi.fn()}
+        onReactClick={vi.fn()}
+        onReactionUnreact={vi.fn()}
+        onOpenReactionModal={vi.fn()}
+        onDirectReaction={vi.fn()}
+        serverId="server-1"
+        channelId="channel-1"
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /translate from actions/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockDetectLanguage).toHaveBeenCalledWith({ text: "hello world" });
+    });
+    expect(mockTranslate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceLanguage: "fr-CA",
+        targetLanguage: "pt-BR",
       }),
     );
   });

--- a/tests/components/MetadataDisplay.test.tsx
+++ b/tests/components/MetadataDisplay.test.tsx
@@ -189,6 +189,7 @@ describe("Metadata Display Features", () => {
         autoFallbackToSingleLine: true,
         mediaVisibilityLevel: 3,
         enableMarkdownRendering: false,
+        translationTargetLanguage: "",
         awayMessage: "",
         quitMessage: "ObsidianIRC - Bringing IRC to the future",
       },

--- a/tests/components/message/MessageItem.translation.test.tsx
+++ b/tests/components/message/MessageItem.translation.test.tsx
@@ -26,7 +26,7 @@ const mockSourceLanguage = vi.fn();
 const mockTranslate = vi.fn();
 const mockTargetLanguage = vi.fn();
 
-vi.mock("../../src/hooks/useLongPress", () => ({
+vi.mock("../../../src/hooks/useLongPress", () => ({
   useLongPress: () => ({
     onTouchStart: vi.fn(),
     onTouchMove: vi.fn(),
@@ -35,11 +35,11 @@ vi.mock("../../src/hooks/useLongPress", () => ({
   }),
 }));
 
-vi.mock("../../src/hooks/useMediaQuery", () => ({
+vi.mock("../../../src/hooks/useMediaQuery", () => ({
   useMediaQuery: () => false,
 }));
 
-vi.mock("../../src/lib/browserTranslation", () => ({
+vi.mock("../../../src/lib/browserTranslation", () => ({
   canUseBrowserTranslation: () => true,
   detectMessageSourceLanguage: (...args: unknown[]) =>
     mockDetectLanguage(...args),
@@ -51,19 +51,19 @@ vi.mock("../../src/lib/browserTranslation", () => ({
   translateWithBrowser: (...args: unknown[]) => mockTranslate(...args),
 }));
 
-vi.mock("../../src/lib/ircClient", () => ({
+vi.mock("../../../src/lib/ircClient", () => ({
   default: {
     getCurrentUser: () => ({ username: "bob" }),
   },
 }));
 
-vi.mock("../../src/lib/ircUtils", () => ({
+vi.mock("../../../src/lib/ircUtils", () => ({
   isUrlFromFilehost: () => false,
   isUserVerified: () => false,
   processMarkdownInText: (content: string) => content,
 }));
 
-vi.mock("../../src/lib/mediaUtils", () => ({
+vi.mock("../../../src/lib/mediaUtils", () => ({
   canShowMedia: () => false,
   extractMediaFromMessage: () => [],
   mediaLevelToSettings: () => ({
@@ -73,11 +73,11 @@ vi.mock("../../src/lib/mediaUtils", () => ({
   }),
 }));
 
-vi.mock("../../src/lib/messageFormatter", () => ({
+vi.mock("../../../src/lib/messageFormatter", () => ({
   stripIrcFormatting: (content: string) => content,
 }));
 
-vi.mock("../../src/store", () => {
+vi.mock("../../../src/store", () => {
   const useStore = Object.assign(
     (selector: (state: typeof mockState) => unknown) => selector(mockState),
     { getState: () => mockState },
@@ -90,25 +90,25 @@ vi.mock("../../src/store", () => {
   };
 });
 
-vi.mock("../../src/components/mobile/MessageBottomSheet", () => ({
+vi.mock("../../../src/components/mobile/MessageBottomSheet", () => ({
   default: () => null,
 }));
 
-vi.mock("../../src/components/ui/LinkWrapper", () => ({
+vi.mock("../../../src/components/ui/LinkWrapper", () => ({
   EnhancedLinkWrapper: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
 }));
 
-vi.mock("../../src/components/message/InviteMessage", () => ({
+vi.mock("../../../src/components/message/InviteMessage", () => ({
   InviteMessage: () => null,
 }));
 
-vi.mock("../../src/components/message/MediaPreview", () => ({
+vi.mock("../../../src/components/message/MediaPreview", () => ({
   MediaPreview: () => null,
 }));
 
-vi.mock("../../src/components/message/index", async () => {
+vi.mock("../../../src/components/message/index", async () => {
   const ReactModule = await import("react");
 
   return {
@@ -138,8 +138,8 @@ vi.mock("../../src/components/message/index", async () => {
   };
 });
 
-import { MessageItem } from "../../src/components/message/MessageItem";
-import type { MessageType } from "../../src/types";
+import { MessageItem } from "../../../src/components/message/MessageItem";
+import type { MessageType } from "../../../src/types";
 
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;

--- a/tests/lib/browserTranslation.test.ts
+++ b/tests/lib/browserTranslation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   canUseBrowserTranslation,
   detectMessageSourceLanguage,
@@ -42,6 +42,10 @@ afterEach(() => {
   }
 });
 
+beforeEach(() => {
+  setSecureContext(true);
+});
+
 describe("browserTranslation", () => {
   test("preserves and canonicalizes full BCP 47 language tags", () => {
     expect(normalizeTranslationLanguageTag("en-US")).toBe("en-US");
@@ -79,7 +83,9 @@ describe("browserTranslation", () => {
   });
 
   test("detects source language with the browser language detector", async () => {
-    const detect = vi.fn().mockResolvedValue([{ detectedLanguage: "pt-BR" }]);
+    const detect = vi
+      .fn()
+      .mockResolvedValue([{ detectedLanguage: "pt-BR", confidence: 0.91 }]);
     const destroy = vi.fn();
 
     vi.stubGlobal("LanguageDetector", {
@@ -87,14 +93,61 @@ describe("browserTranslation", () => {
     });
 
     await expect(
-      detectMessageSourceLanguage({ text: "ola mundo" }),
+      detectMessageSourceLanguage({ text: "ola mundo como voce esta hoje" }),
     ).resolves.toBe("pt-BR");
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  test("returns null for short text because language detection would be unreliable", async () => {
+    const detect = vi.fn();
+
+    vi.stubGlobal("LanguageDetector", {
+      create: vi.fn().mockResolvedValue({ detect, destroy: vi.fn() }),
+    });
+
+    await expect(
+      detectMessageSourceLanguage({ text: "hola mundo" }),
+    ).resolves.toBe(null);
+    expect(detect).not.toHaveBeenCalled();
+  });
+
+  test("returns null for low-confidence language detection results", async () => {
+    const detect = vi
+      .fn()
+      .mockResolvedValue([{ detectedLanguage: "pt-BR", confidence: 0.2 }]);
+    const destroy = vi.fn();
+
+    vi.stubGlobal("LanguageDetector", {
+      create: vi.fn().mockResolvedValue({ detect, destroy }),
+    });
+
+    await expect(
+      detectMessageSourceLanguage({ text: "ola mundo como voce esta hoje" }),
+    ).resolves.toBeNull();
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  test("returns null for undetermined language detection results", async () => {
+    const detect = vi
+      .fn()
+      .mockResolvedValue([{ detectedLanguage: "und", confidence: 0.99 }]);
+    const destroy = vi.fn();
+
+    vi.stubGlobal("LanguageDetector", {
+      create: vi.fn().mockResolvedValue({ detect, destroy }),
+    });
+
+    await expect(
+      detectMessageSourceLanguage({ text: "ola mundo como voce esta hoje" }),
+    ).resolves.toBeNull();
     expect(destroy).toHaveBeenCalledOnce();
   });
 
   test("returns null when language detection is unavailable", async () => {
     await expect(
-      detectMessageSourceLanguage({ text: "hola mundo" }),
+      detectMessageSourceLanguage({
+        text: "hola mundo desde una prueba larga",
+      }),
     ).resolves.toBeNull();
   });
 

--- a/tests/lib/browserTranslation.test.ts
+++ b/tests/lib/browserTranslation.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   canUseBrowserTranslation,
+  detectMessageSourceLanguage,
   getBrowserTranslationAvailability,
   getMessageSourceLanguage,
   getPreferredTranslationTargetLanguage,
@@ -9,6 +10,11 @@ import {
   translateWithBrowser,
 } from "../../src/lib/browserTranslation";
 
+const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "navigator",
+);
+
 function setSecureContext(value: boolean) {
   Object.defineProperty(window, "isSecureContext", {
     configurable: true,
@@ -16,52 +22,80 @@ function setSecureContext(value: boolean) {
   });
 }
 
+function setNavigatorLanguages(language: string, languages: string[]) {
+  Object.defineProperty(window, "navigator", {
+    configurable: true,
+    value: {
+      ...window.navigator,
+      language,
+      languages,
+    },
+  });
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   setSecureContext(true);
+  if (originalNavigatorDescriptor) {
+    Object.defineProperty(window, "navigator", originalNavigatorDescriptor);
+  }
 });
 
 describe("browserTranslation", () => {
-  test("normalizes translation language tags to primary subtags", () => {
-    expect(normalizeTranslationLanguageTag("en-US")).toBe("en");
-    expect(normalizeTranslationLanguageTag(" ES ")).toBe("es");
+  test("preserves and canonicalizes full BCP 47 language tags", () => {
+    expect(normalizeTranslationLanguageTag("en-US")).toBe("en-US");
+    expect(normalizeTranslationLanguageTag("zh-hant")).toBe("zh-Hant");
     expect(normalizeTranslationLanguageTag(undefined)).toBeNull();
   });
 
   test("derives preferred target language from navigator", () => {
-    Object.defineProperty(window, "navigator", {
-      configurable: true,
-      value: {
-        language: "pt-BR",
-        languages: ["pt-BR", "en-US"],
-      },
-    });
+    setNavigatorLanguages("pt-BR", ["pt-BR", "en-US"]);
 
-    expect(getPreferredTranslationTargetLanguage()).toBe("pt");
+    expect(getPreferredTranslationTargetLanguage()).toBe("pt-BR");
   });
 
   test("prefers an explicit target language setting over navigator", () => {
-    Object.defineProperty(window, "navigator", {
-      configurable: true,
-      value: {
-        language: "pt-BR",
-        languages: ["pt-BR", "en-US"],
-      },
-    });
+    setNavigatorLanguages("pt-BR", ["pt-BR", "en-US"]);
 
     expect(getPreferredTranslationTargetLanguageFromSetting("es-MX")).toBe(
-      "es",
+      "es-MX",
     );
   });
 
-  test("derives source language from message tags with english fallback", () => {
+  test("falls back to the browser language when the setting is empty", () => {
+    setNavigatorLanguages("pt-BR", ["pt-BR", "en-US"]);
+
+    expect(getPreferredTranslationTargetLanguageFromSetting("")).toBe("pt-BR");
+  });
+
+  test("derives source language from message tags without forcing english", () => {
     expect(
       getMessageSourceLanguage({
         "+draft/language": "fr-CA",
       }),
-    ).toBe("fr");
-    expect(getMessageSourceLanguage()).toBe("en");
+    ).toBe("fr-CA");
+    expect(getMessageSourceLanguage()).toBeNull();
+  });
+
+  test("detects source language with the browser language detector", async () => {
+    const detect = vi.fn().mockResolvedValue([{ detectedLanguage: "pt-BR" }]);
+    const destroy = vi.fn();
+
+    vi.stubGlobal("LanguageDetector", {
+      create: vi.fn().mockResolvedValue({ detect, destroy }),
+    });
+
+    await expect(
+      detectMessageSourceLanguage({ text: "ola mundo" }),
+    ).resolves.toBe("pt-BR");
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  test("returns null when language detection is unavailable", async () => {
+    await expect(
+      detectMessageSourceLanguage({ text: "hola mundo" }),
+    ).resolves.toBeNull();
   });
 
   test("reports unsupported when Translator is missing", async () => {

--- a/tests/lib/browserTranslation.test.ts
+++ b/tests/lib/browserTranslation.test.ts
@@ -144,6 +144,8 @@ describe("browserTranslation", () => {
   });
 
   test("returns null when language detection is unavailable", async () => {
+    vi.stubGlobal("LanguageDetector", undefined);
+
     await expect(
       detectMessageSourceLanguage({
         text: "hola mundo desde una prueba larga",
@@ -153,6 +155,7 @@ describe("browserTranslation", () => {
 
   test("reports unsupported when Translator is missing", async () => {
     setSecureContext(true);
+    vi.stubGlobal("Translator", undefined);
 
     expect(canUseBrowserTranslation()).toBe(false);
     await expect(

--- a/tests/lib/browserTranslation.test.ts
+++ b/tests/lib/browserTranslation.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  canUseBrowserTranslation,
+  getBrowserTranslationAvailability,
+  getMessageSourceLanguage,
+  getPreferredTranslationTargetLanguage,
+  getPreferredTranslationTargetLanguageFromSetting,
+  normalizeTranslationLanguageTag,
+  translateWithBrowser,
+} from "../../src/lib/browserTranslation";
+
+function setSecureContext(value: boolean) {
+  Object.defineProperty(window, "isSecureContext", {
+    configurable: true,
+    value,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  setSecureContext(true);
+});
+
+describe("browserTranslation", () => {
+  test("normalizes translation language tags to primary subtags", () => {
+    expect(normalizeTranslationLanguageTag("en-US")).toBe("en");
+    expect(normalizeTranslationLanguageTag(" ES ")).toBe("es");
+    expect(normalizeTranslationLanguageTag(undefined)).toBeNull();
+  });
+
+  test("derives preferred target language from navigator", () => {
+    Object.defineProperty(window, "navigator", {
+      configurable: true,
+      value: {
+        language: "pt-BR",
+        languages: ["pt-BR", "en-US"],
+      },
+    });
+
+    expect(getPreferredTranslationTargetLanguage()).toBe("pt");
+  });
+
+  test("prefers an explicit target language setting over navigator", () => {
+    Object.defineProperty(window, "navigator", {
+      configurable: true,
+      value: {
+        language: "pt-BR",
+        languages: ["pt-BR", "en-US"],
+      },
+    });
+
+    expect(getPreferredTranslationTargetLanguageFromSetting("es-MX")).toBe(
+      "es",
+    );
+  });
+
+  test("derives source language from message tags with english fallback", () => {
+    expect(
+      getMessageSourceLanguage({
+        "+draft/language": "fr-CA",
+      }),
+    ).toBe("fr");
+    expect(getMessageSourceLanguage()).toBe("en");
+  });
+
+  test("reports unsupported when Translator is missing", async () => {
+    setSecureContext(true);
+
+    expect(canUseBrowserTranslation()).toBe(false);
+    await expect(
+      getBrowserTranslationAvailability({
+        sourceLanguage: "en",
+        targetLanguage: "es",
+      }),
+    ).resolves.toBe("unsupported");
+  });
+
+  test("reports insecure-context before touching Translator", async () => {
+    const availability = vi.fn();
+    setSecureContext(false);
+    vi.stubGlobal("Translator", { availability, create: vi.fn() });
+
+    expect(canUseBrowserTranslation()).toBe(false);
+    await expect(
+      getBrowserTranslationAvailability({
+        sourceLanguage: "en",
+        targetLanguage: "es",
+      }),
+    ).resolves.toBe("insecure-context");
+    expect(availability).not.toHaveBeenCalled();
+  });
+
+  test("maps native availability values", async () => {
+    setSecureContext(true);
+    vi.stubGlobal("Translator", {
+      availability: vi.fn().mockResolvedValue("downloadable"),
+      create: vi.fn(),
+    });
+
+    await expect(
+      getBrowserTranslationAvailability({
+        sourceLanguage: "en",
+        targetLanguage: "es",
+      }),
+    ).resolves.toBe("downloadable");
+  });
+
+  test("returns unavailable for same-language requests", async () => {
+    const availability = vi.fn();
+    setSecureContext(true);
+    vi.stubGlobal("Translator", {
+      availability,
+      create: vi.fn(),
+    });
+
+    await expect(
+      getBrowserTranslationAvailability({
+        sourceLanguage: "en",
+        targetLanguage: "en",
+      }),
+    ).resolves.toBe("unavailable");
+    expect(availability).not.toHaveBeenCalled();
+  });
+
+  test("creates, translates, reports progress, and destroys", async () => {
+    const addEventListener = vi.fn(
+      (
+        _event: string,
+        listener: (event: Pick<ProgressEvent, "loaded">) => void,
+      ) => {
+        listener({ loaded: 0.5 });
+      },
+    );
+    const destroy = vi.fn();
+    const translate = vi.fn().mockResolvedValue("hola");
+    const create = vi.fn().mockResolvedValue({ translate, destroy });
+    const progress = vi.fn();
+
+    setSecureContext(true);
+    vi.stubGlobal("Translator", {
+      availability: vi.fn(),
+      create,
+    });
+
+    await expect(
+      translateWithBrowser({
+        sourceLanguage: "en",
+        targetLanguage: "es",
+        text: "hello",
+        onDownloadProgress: progress,
+      }),
+    ).resolves.toBe("hola");
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceLanguage: "en",
+        targetLanguage: "es",
+        monitor: expect.any(Function),
+      }),
+    );
+
+    const [{ monitor }] = create.mock.calls[0];
+    monitor({ addEventListener } as unknown as EventTarget);
+
+    expect(addEventListener).toHaveBeenCalledWith(
+      "downloadprogress",
+      expect.any(Function),
+    );
+    expect(progress).toHaveBeenCalledWith(0.5);
+    expect(translate).toHaveBeenCalledWith("hello", { signal: undefined });
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  test("still destroys the translator when translation fails", async () => {
+    const destroy = vi.fn();
+    const translate = vi.fn().mockRejectedValue(new Error("boom"));
+
+    setSecureContext(true);
+    vi.stubGlobal("Translator", {
+      availability: vi.fn(),
+      create: vi.fn().mockResolvedValue({ translate, destroy }),
+    });
+
+    await expect(
+      translateWithBrowser({
+        sourceLanguage: "en",
+        targetLanguage: "es",
+        text: "hello",
+      }),
+    ).rejects.toThrow("boom");
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/store/index.test.ts
+++ b/tests/store/index.test.ts
@@ -58,6 +58,15 @@ describe("Store", () => {
       const newTheme = useStore.getState().ui.isDarkMode;
       expect(newTheme).not.toBe(initialTheme);
     });
+
+    test("should update translation target language", () => {
+      const { updateGlobalSettings } = useStore.getState();
+
+      updateGlobalSettings({ translationTargetLanguage: "es" });
+      expect(useStore.getState().globalSettings.translationTargetLanguage).toBe(
+        "es",
+      );
+    });
   });
 
   describe("server selection", () => {

--- a/tests/store/join.test.ts
+++ b/tests/store/join.test.ts
@@ -38,6 +38,7 @@ function setupServer(channelOverrides: Partial<Channel> = {}) {
     globalSettings: {
       showEvents: true,
       showJoinsParts: true,
+      translationTargetLanguage: "",
     },
   } as unknown as AppState);
 }

--- a/tests/store/localStorage.test.ts
+++ b/tests/store/localStorage.test.ts
@@ -72,6 +72,12 @@ describe("settings.load migration", () => {
     // Old flag is left as-is when not migrating (no need to clean it up)
   });
 
+  test("preserves explicit translation target language", () => {
+    mockStored({ translationTargetLanguage: "es" });
+    const result = settings.load();
+    expect(result.translationTargetLanguage).toBe("es");
+  });
+
   test("returns empty object on invalid JSON", () => {
     vi.mocked(window.localStorage.getItem).mockReturnValue("not-json");
     const result = settings.load();


### PR DESCRIPTION
## Summary

This PR adds an optional client-side translation action to individual messages as progressive enhancement. It is intentionally scoped as a local browser feature and does not claim to implement issue #101 as written, since #101 asks for an IRC-side/server-side translation facility.

This PR focuses exclusively on dynamic chat message translation. Unlike the i18n efforts in #171 (which localize the static UI/dictionaries), this implementation uses the Browser AI APIs to translate real-time user content on demand. Both features are complementary: #171 makes the app's interface accessible, while this PR makes the conversation accessible.

## What this does

- Adds a per-message Translate action in desktop and mobile message actions.
- Uses the browser Translator API only when the runtime supports it.
- Requires secure context and explicit user interaction.
- Keeps the original message content unchanged and renders translated output as a secondary layer.
- Adds an explicit target-language preference, with browser language as fallback.

## What this does not do

- No IRC-side translation.
- No automatic translation of all incoming messages.
- No backend dependency in this PR.
- No claim that this resolves Automatic language translation #101 end-to-end.

## Follow-up hardening included on this branch

Since opening the PR, this branch also picked up narrow hardening specific to the browser-translation flow itself:

- stale-request / unmount-safe translation lifecycle handling so older async runs cannot overwrite newer UI state
- detector-quality guards for short text, low-confidence results, and `und`
- deterministic focused tests for the browser-translation path
- mirrored component test placement for `MessageItem`

## How this now composes with the other translation tracks

This PR still stands on its own as a browser-native, backend-free enhancement.

That said, the surrounding follow-up work means the client-side path is now better prepared for maintainers who want to evaluate a self-hosted backend later:

- **#173** = browser-native message translation + direct runtime hardening
- **#174** = adapter boundary for self-hosted / swappable backends such as LibreTranslate-style deployments
- **#175** = IRCv3 protocol/helper correctness hardening that lowers risk for multiline/tag-driven follow-up work

So while this PR does **not** itself add a backend, it does help prove and stabilize the user-facing interaction model. Combined with #174 and #175, the remaining work for a self-hosted backend experiment shifts more toward deployment / proxy / service configuration than toward re-inventing the frontend UX.

## Self-hosted deployment follow-up

For maintainers who want a concrete next-step document for self-hosted translation infrastructure, I wrote a separate follow-up note here:

- **Self-hosted translation follow-up (LibreTranslate / proxy / Docker):** https://gist.github.com/louzt/d12a4fa925446630290c0e1171ea6131

That note is intentionally framed as deployment guidance and adapter follow-up, **not** as proof that #173 already delivers IRC-side translation.

## Why this split is useful

This gives users an immediate privacy-preserving local enhancement where supported, while keeping the door open for:

- a separate adapter-driven fallback
- self-hosted backend deployments
- or a future IRC-side solution

It also keeps review boundaries cleaner:

- this PR = browser-native message translation + its direct runtime hardening
- #175 = generic IRCv3 protocol/helper correctness improvements

## Standards reference

MDN Translator API:
https://developer.mozilla.org/en-US/docs/Web/API/Translator

MDN Translator and Language Detector APIs:
https://developer.mozilla.org/en-US/docs/Web/API/Translator_and_Language_Detector_APIs/Using
