### PR TITLE
Add translation adapter interface for self-hosted backends

### DIFF
--- a/src/lib/translation/adapters.ts
+++ b/src/lib/translation/adapters.ts
@@ -1,0 +1,99 @@
+export interface TranslationRequest {
+  text: string;
+  sourceLanguage: string;
+  targetLanguage: string;
+  signal?: AbortSignal;
+}
+
+export interface TranslationResponse {
+  translatedText: string;
+  detectedLanguage?: string;
+  provider: string;
+}
+
+export interface TranslationProvider {
+  id: string;
+  label: string;
+  translate(request: TranslationRequest): Promise<TranslationResponse>;
+}
+
+export interface LibreTranslateAdapterOptions {
+  endpoint: string;
+  apiKey?: string;
+  format?: "text" | "html";
+}
+
+interface LibreTranslateSuccessResponse {
+  translatedText?: string;
+  detectedLanguage?: {
+    language?: string;
+  };
+  error?: string;
+}
+
+function normalizeEndpoint(endpoint: string): string {
+  return endpoint.replace(/\/+$/, "");
+}
+
+export class LibreTranslateAdapter implements TranslationProvider {
+  readonly id = "libretranslate";
+  readonly label = "LibreTranslate";
+
+  private readonly endpoint: string;
+  private readonly apiKey?: string;
+  private readonly format: "text" | "html";
+
+  constructor({
+    endpoint,
+    apiKey,
+    format = "text",
+  }: LibreTranslateAdapterOptions) {
+    this.endpoint = normalizeEndpoint(endpoint);
+    this.apiKey = apiKey;
+    this.format = format;
+  }
+
+  async translate({
+    text,
+    sourceLanguage,
+    targetLanguage,
+    signal,
+  }: TranslationRequest): Promise<TranslationResponse> {
+    const response = await fetch(`${this.endpoint}/translate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        q: text,
+        source: sourceLanguage,
+        target: targetLanguage,
+        format: this.format,
+        api_key: this.apiKey,
+      }),
+      signal,
+    });
+
+    const payload = (await response.json()) as LibreTranslateSuccessResponse;
+
+    if (!response.ok) {
+      throw new Error(payload.error || "LibreTranslate request failed.");
+    }
+
+    if (!payload.translatedText) {
+      throw new Error("LibreTranslate returned no translated text.");
+    }
+
+    return {
+      translatedText: payload.translatedText,
+      detectedLanguage: payload.detectedLanguage?.language,
+      provider: this.id,
+    };
+  }
+}
+
+export function createLibreTranslateAdapter(
+  options: LibreTranslateAdapterOptions,
+): TranslationProvider {
+  return new LibreTranslateAdapter(options);
+}

--- a/src/lib/translation/index.ts
+++ b/src/lib/translation/index.ts
@@ -1,0 +1,10 @@
+export type {
+  LibreTranslateAdapterOptions,
+  TranslationProvider,
+  TranslationRequest,
+  TranslationResponse,
+} from "./adapters";
+export {
+  createLibreTranslateAdapter,
+  LibreTranslateAdapter,
+} from "./adapters";

--- a/tests/lib/libreTranslateAdapter.test.ts
+++ b/tests/lib/libreTranslateAdapter.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  createLibreTranslateAdapter,
+  LibreTranslateAdapter,
+} from "../../src/lib/translation/adapters";
+
+function makeResponse(body: Record<string, unknown>, ok = true): Response {
+  return {
+    ok,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("LibreTranslateAdapter", () => {
+  test("posts translation requests to /translate", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      makeResponse({
+        translatedText: "hola mundo",
+        detectedLanguage: { language: "en" },
+      }),
+    );
+
+    const adapter = new LibreTranslateAdapter({
+      endpoint: "https://translate.example.com/",
+    });
+
+    await expect(
+      adapter.translate({
+        text: "hello world",
+        sourceLanguage: "en",
+        targetLanguage: "es",
+      }),
+    ).resolves.toEqual({
+      translatedText: "hola mundo",
+      detectedLanguage: "en",
+      provider: "libretranslate",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://translate.example.com/translate",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+
+  test("includes api key and html format when configured", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      makeResponse({ translatedText: "hola" }),
+    );
+
+    const adapter = createLibreTranslateAdapter({
+      endpoint: "https://translate.example.com",
+      apiKey: "secret",
+      format: "html",
+    });
+
+    await adapter.translate({
+      text: "<b>hello</b>",
+      sourceLanguage: "en",
+      targetLanguage: "es",
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://translate.example.com/translate",
+      expect.objectContaining({
+        body: JSON.stringify({
+          q: "<b>hello</b>",
+          source: "en",
+          target: "es",
+          format: "html",
+          api_key: "secret",
+        }),
+      }),
+    );
+  });
+
+  test("surfaces backend errors", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      makeResponse({ error: "rate limited" }, false),
+    );
+
+    const adapter = new LibreTranslateAdapter({
+      endpoint: "https://translate.example.com",
+    });
+
+    await expect(
+      adapter.translate({
+        text: "hello",
+        sourceLanguage: "en",
+        targetLanguage: "es",
+      }),
+    ).rejects.toThrow("rate limited");
+  });
+
+  test("fails when translatedText is missing", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeResponse({}));
+
+    const adapter = new LibreTranslateAdapter({
+      endpoint: "https://translate.example.com",
+    });
+
+    await expect(
+      adapter.translate({
+        text: "hello",
+        sourceLanguage: "en",
+        targetLanguage: "es",
+      }),
+    ).rejects.toThrow("LibreTranslate returned no translated text.");
+  });
+});


### PR DESCRIPTION
## Summary

This PR introduces a translation adapter boundary plus a LibreTranslate-oriented adapter path.

It is intentionally separate from the browser-native PR so the self-hosted / backend-driven path can be evaluated independently from the local Translator API experiment.

## What this does

- introduces a swappable translation adapter interface
- adds an initial self-hosted backend-oriented translation path
- keeps the translation backend behind an adapter seam instead of coupling the client to one concrete service shape

## What this does not do

- no claim that this alone implements issue #101 as an IRC-side/server-side feature
- no requirement that ObsidianIRC ship with a hosted translation service
- no attempt to replace the browser-native progressive-enhancement path in #173

## How this relates to the other open translation work

- **#171** = UI localization / dictionaries
- **#173** = browser-native per-message translation using the Translator API as optional progressive enhancement
- **#174** = backend / self-hosted adapter seam
- **#175** = IRCv3 helper/protocol hardening useful for translation-adjacent follow-up work

The intent is to keep these reviewable independently:

- #173 proves the client-side interaction model without a backend dependency
- #174 provides a path for maintainers who prefer self-hosted backends such as LibreTranslate-style deployments
- #175 keeps generic protocol/helper correctness separate from product-scope translation review

## Deployment follow-up

For maintainers who want an operational next-step note for a self-hosted deployment, I wrote a separate follow-up here:

- **Self-hosted translation follow-up (LibreTranslate / proxy / Docker):** https://gist.github.com/louzt/d12a4fa925446630290c0e1171ea6131

That note is intentionally about deployment and reverse-proxy/service layout. It should be read as follow-up guidance for the self-hosted path, not as proof that this PR already provides an IRC-side network translation layer.
