### PR TITLE
refactor: add socket factory seam under IRC transport

### DIFF
--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -14,6 +14,8 @@ export interface ISocket {
   readyState: number;
 }
 
+export type SocketFactory = (url: string) => ISocket;
+
 export class TCPSocket implements ISocket {
   private clientId: string;
   private isConnected = false;
@@ -161,7 +163,7 @@ export class WebSocketWrapper implements ISocket {
   }
 }
 
-export function createSocket(url: string): ISocket {
+const defaultSocketFactory: SocketFactory = (url: string) => {
   if (url.startsWith("wss://")) {
     return new WebSocketWrapper(url);
   }
@@ -169,4 +171,18 @@ export function createSocket(url: string): ISocket {
     return new TCPSocket(url);
   }
   throw new Error("Unsupported socket protocol");
+};
+
+let socketFactory: SocketFactory = defaultSocketFactory;
+
+export function createSocket(url: string): ISocket {
+  return socketFactory(url);
+}
+
+export function setSocketFactory(factory: SocketFactory): void {
+  socketFactory = factory;
+}
+
+export function resetSocketFactory(): void {
+  socketFactory = defaultSocketFactory;
 }

--- a/tests/lib/socketFactory.test.ts
+++ b/tests/lib/socketFactory.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSING = 2;
+  readonly CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  bufferedAmount = 0;
+  extensions = "";
+  protocol = "";
+  binaryType: BinaryType = "blob";
+  url: string;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  send(): void {}
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+}
+
+vi.stubGlobal("WebSocket", MockWebSocket);
+
+import {
+  createSocket,
+  resetSocketFactory,
+  setSocketFactory,
+  TCPSocket,
+  WebSocketWrapper,
+} from "../../src/lib/socket";
+
+describe("socket factory", () => {
+  afterEach(() => {
+    resetSocketFactory();
+    vi.clearAllMocks();
+  });
+
+  it("allows a custom socket factory to be injected", () => {
+    const fakeSocket = {
+      onopen: null,
+      onmessage: null,
+      onerror: null,
+      onclose: null,
+      send: vi.fn(),
+      close: vi.fn(),
+      readyState: 1,
+    };
+    const factory = vi.fn(() => fakeSocket);
+
+    setSocketFactory(factory);
+
+    const socket = createSocket("wss://irc.example.com:443");
+
+    expect(factory).toHaveBeenCalledWith("wss://irc.example.com:443");
+    expect(socket).toBe(fakeSocket);
+  });
+
+  it("keeps websocket routing as the default behavior", () => {
+    const socket = createSocket("wss://irc.example.com:443");
+
+    expect(socket).toBeInstanceOf(WebSocketWrapper);
+  });
+
+  it("keeps tauri tcp/tls routing as the default behavior", () => {
+    const socket = createSocket("ircs://irc.example.com:6697");
+
+    expect(socket).toBeInstanceOf(TCPSocket);
+  });
+});


### PR DESCRIPTION
## Summary

This PR opens a narrow transport seam under ObsidianIRC's existing socket layer without changing default behavior.

## What changes

- keeps the current routing exactly as-is:
  - `wss://` -> `WebSocketWrapper`
  - `irc://` / `ircs://` -> `TCPSocket`
- adds an injectable `SocketFactory`
- adds focused tests for:
  - custom factory injection
  - default websocket routing
  - default tauri TCP/TLS routing

## Why

ObsidianIRC already has protocol selection, but the routing was still effectively hardcoded.
An injectable seam makes future transport experimentation and testing cleaner while preserving current behavior.

This mirrors the same direction already applied in the related tobby refactor, but fits ObsidianIRC's existing architecture where WebSocket support already exists.

## Verification

- `npm run format`
- `npm run fix:unsafe`
- `npm run test`
- `npm run build`

## Notes

The full test suite passes, though the repository already emits pre-existing jsdom/React test warnings around `HTMLMediaElement.prototype.pause` and some `act(...)` coverage in unrelated tests.
