### PR TITLE
Lifecycle hardening for IRC client behavior

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # ObsidianIRC Architecture
 
 > **Modern IRC Client** - React + TypeScript + TailwindCSS + Tauri
-> Next-generation IRC client supporting websockets only
+> Next-generation IRC client with WebSocket support in web builds and native TCP/TLS transport in Tauri builds
 
 ## 🏗️ Project Structure
 
@@ -75,14 +75,30 @@ interface AppState {
 - Optimistic UI updates
 
 ### IRC Protocol Layer
-**Location:** `src/lib/ircClient.ts`
+**Location:** `src/lib/irc/IRCClient.ts`
 
 Event-driven IRC client supporting:
-- WebSocket-only connections (no raw TCP)
+- WebSocket connections for browser-compatible paths
+- Native TCP/TLS connections through the Tauri backend on desktop builds
 - SASL authentication
 - IRC v3 message tags
 - Capability negotiation
 - Multi-server management
+
+### Transport Layer
+**Locations:** `src/lib/socket.ts`, `src-tauri/src/socket.rs`
+
+ObsidianIRC has a split transport model:
+
+- `wss://` routes through `WebSocketWrapper` in the frontend.
+- `irc://` and `ircs://` route through `TCPSocket` in the frontend.
+- `TCPSocket` bridges to Tauri commands (`connect`, `listen`, `send`, `disconnect`) implemented in Rust.
+- The Rust backend owns the real TCP/TLS socket lifecycle, reads and writes IRC lines, and emits `tcp-message` events back to the frontend.
+
+This means transport hardening work usually belongs in two places:
+
+- frontend lifecycle and state transitions in `IRCClient` / `socket.ts`
+- native socket behavior and shutdown semantics in `src-tauri/src/socket.rs`
 
 **Event System:**
 ```typescript

--- a/src-tauri/src/socket.rs
+++ b/src-tauri/src/socket.rs
@@ -51,6 +51,14 @@ struct MessageData {
     data: Vec<u8>,
 }
 
+async fn take_connection(
+    state: &Arc<Mutex<HashMap<String, ConnectionHandle>>>,
+    client_id: &str,
+) -> Option<ConnectionHandle> {
+    let mut connections = state.lock().await;
+    connections.remove(client_id)
+}
+
 /// Read task for handling incoming data from the socket
 async fn read_task<R>(
     client_id: String,
@@ -66,6 +74,11 @@ async fn read_task<R>(
     loop {
         match reader.read(&mut read_buf).await {
             Ok(0) => {
+                let was_tracked = take_connection(&state, &client_id).await.is_some();
+                if !was_tracked {
+                    break;
+                }
+
                 // Connection closed by server
                 // Emit any remaining partial data as a final message
                 if !line_buffer.is_empty() {
@@ -87,10 +100,6 @@ async fn read_task<R>(
                         connected: Some(false),
                     },
                 });
-
-                // Remove connection from state
-                let mut connections = state.lock().await;
-                connections.remove(&client_id);
                 break;
             }
             Ok(n) => {
@@ -122,6 +131,11 @@ async fn read_task<R>(
                 }
             }
             Err(e) => {
+                let was_tracked = take_connection(&state, &client_id).await.is_some();
+                if !was_tracked {
+                    break;
+                }
+
                 // Read error - emit error event and stop
                 let _ = app_handle.emit("tcp-message", ReceivedPayload {
                     id: client_id.clone(),
@@ -131,10 +145,6 @@ async fn read_task<R>(
                         connected: Some(false),
                     },
                 });
-
-                // Remove connection from state
-                let mut connections = state.lock().await;
-                connections.remove(&client_id);
                 break;
             }
         }
@@ -340,16 +350,14 @@ fn parse_host_port(host_port: &str, default_port: u16) -> Result<(String, u16), 
 /// Disconnect a specific client connection
 #[tauri::command]
 pub async fn disconnect(client_id: String, state: State<'_, SocketState>) -> Result<(), String> {
-    let mut connections = state.0.lock().await;
-    if let Some(mut handle) = connections.remove(&client_id) {
+    if let Some(mut handle) = take_connection(&state.0, &client_id).await {
         // Send shutdown signal if available
         if let Some(shutdown_tx) = handle.shutdown_tx.take() {
             let _ = shutdown_tx.send(());
         }
-        Ok(())
-    } else {
-        Err(format!("No connection found for client_id: {}", client_id))
     }
+
+    Ok(())
 }
 
 /// Start listening for messages from all active connections
@@ -386,5 +394,33 @@ pub async fn send(
         Ok(())
     } else {
         Err(format!("No connection found for client_id: {}", client_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_connection_handle() -> ConnectionHandle {
+        let (write_tx, _write_rx) = mpsc::channel(1);
+        let (shutdown_tx, _shutdown_rx) = oneshot::channel();
+
+        ConnectionHandle {
+            write_tx,
+            shutdown_tx: Some(shutdown_tx),
+        }
+    }
+
+    #[tokio::test]
+    async fn take_connection_is_idempotent() {
+        let state = Arc::new(Mutex::new(HashMap::new()));
+
+        {
+            let mut connections = state.lock().await;
+            connections.insert("client-1".to_string(), make_connection_handle());
+        }
+
+        assert!(take_connection(&state, "client-1").await.is_some());
+        assert!(take_connection(&state, "client-1").await.is_none());
     }
 }

--- a/src/lib/irc/IRCClient.ts
+++ b/src/lib/irc/IRCClient.ts
@@ -619,7 +619,6 @@ export class IRCClient implements IRCClientContext {
         status: "online",
       });
       this.nicks.set(server.id, nickname);
-      this.intentionalDisconnects.delete(server.id);
 
       socket.onopen = () => {
         //registerAllProtocolHandlers(this);
@@ -656,6 +655,7 @@ export class IRCClient implements IRCClientContext {
 
         socket.onclose = () => {
           if (this.intentionalDisconnects.has(server.id)) {
+            this.intentionalDisconnects.delete(server.id);
             this.stopWebSocketPing(server.id);
             this.sockets.delete(server.id);
             this.pendingConnections.delete(connectionKey);
@@ -731,9 +731,7 @@ export class IRCClient implements IRCClientContext {
       const CONNECTING = 0;
       const OPEN = 1;
 
-      if (socket.readyState === CONNECTING || socket.readyState === OPEN) {
-        this.intentionalDisconnects.add(serverId);
-      }
+      this.intentionalDisconnects.add(serverId);
 
       if (socket.readyState === OPEN && server?.isConnected) {
         const message =

--- a/src/lib/irc/IRCClient.ts
+++ b/src/lib/irc/IRCClient.ts
@@ -391,6 +391,7 @@ type EventCallback<K extends EventKey> = (data: EventMap[K]) => void;
 
 export class IRCClient implements IRCClientContext {
   private sockets: Map<string, ISocket> = new Map();
+  private intentionalDisconnects: Set<string> = new Set();
   servers: Map<string, Server> = new Map();
   nicks: Map<string, string> = new Map();
   currentUsers: Map<string, User | null> = new Map(); // Per-server current users
@@ -490,6 +491,10 @@ export class IRCClient implements IRCClientContext {
     serverId?: string,
   ): Promise<Server> {
     const connectionKey = `${host}:${port}`;
+
+    if (serverId) {
+      this.intentionalDisconnects.delete(serverId);
+    }
 
     // Check if there's already a pending connection to this server
     const existingConnection = this.pendingConnections.get(connectionKey);
@@ -614,6 +619,7 @@ export class IRCClient implements IRCClientContext {
         status: "online",
       });
       this.nicks.set(server.id, nickname);
+      this.intentionalDisconnects.delete(server.id);
 
       socket.onopen = () => {
         //registerAllProtocolHandlers(this);
@@ -649,6 +655,13 @@ export class IRCClient implements IRCClientContext {
         // to ensure connection is fully established before sending PINGs
 
         socket.onclose = () => {
+          if (this.intentionalDisconnects.has(server.id)) {
+            this.stopWebSocketPing(server.id);
+            this.sockets.delete(server.id);
+            this.pendingConnections.delete(connectionKey);
+            return;
+          }
+
           if (!this.servers.has(server.id)) {
             return;
           }
@@ -712,13 +725,29 @@ export class IRCClient implements IRCClientContext {
 
   disconnect(serverId: string, quitMessage?: string): void {
     const socket = this.sockets.get(serverId);
+    const server = this.servers.get(serverId);
+
     if (socket) {
-      const message = quitMessage || "ObsidianIRC - Bringing IRC to the future";
-      socket.send(`QUIT :${message}`);
-      socket.close();
+      const CONNECTING = 0;
+      const OPEN = 1;
+
+      if (socket.readyState === CONNECTING || socket.readyState === OPEN) {
+        this.intentionalDisconnects.add(serverId);
+      }
+
+      if (socket.readyState === OPEN && server?.isConnected) {
+        const message =
+          quitMessage || "ObsidianIRC - Bringing IRC to the future";
+        socket.send(`QUIT :${message}`);
+      }
+
+      if (socket.readyState === CONNECTING || socket.readyState === OPEN) {
+        socket.close();
+      }
+
       this.sockets.delete(serverId);
     }
-    const server = this.servers.get(serverId);
+
     if (server) {
       server.isConnected = false;
       server.connectionState = "disconnected";
@@ -742,6 +771,7 @@ export class IRCClient implements IRCClientContext {
 
   removeServer(serverId: string): void {
     this.disconnect(serverId);
+    this.intentionalDisconnects.delete(serverId);
     this.servers.delete(serverId);
     this.capNegotiationComplete.delete(serverId);
     this.pendingCapReqs.delete(serverId);

--- a/src/lib/irc/IRCClient.ts
+++ b/src/lib/irc/IRCClient.ts
@@ -11,9 +11,8 @@ import type {
   Server,
   User,
 } from "../../types";
-import { parseIrcUrl } from "../ircUrlParser";
 import { parseMessageTags } from "../ircUtils";
-import { createSocket, type ISocket } from "../socket";
+import { createSocket, type ISocket, resolveSocketTarget } from "../socket";
 import { IRC_DISPATCH } from "./handlers";
 import type { IRCClientContext } from "./IRCClientContext";
 
@@ -514,47 +513,10 @@ export class IRCClient implements IRCClientContext {
 
     // Create a new connection promise and store it
     const connectionPromise = new Promise<Server>((resolve, reject) => {
-      let protocol: "wss" | "ircs" | "irc" = "wss";
-      let actualHost = host;
-      let actualPort = port;
-      let actualPath = "";
-
-      if (host.startsWith("irc://") || host.startsWith("ircs://")) {
-        // Parse the IRC URL using centralized parser (Android-compatible)
-        const parsed = parseIrcUrl(host);
-
-        protocol = parsed.scheme;
-        actualHost = parsed.host;
-        actualPort = parsed.port;
-      } else if (host.startsWith("wss://")) {
-        // Use URL constructor to preserve path/query (e.g. wss://host/websocket?token=...)
-        try {
-          const parsed = new URL(host);
-          actualHost = parsed.hostname;
-          actualPort = parsed.port ? Number.parseInt(parsed.port, 10) : port;
-          actualPath =
-            parsed.pathname !== "/"
-              ? parsed.pathname + parsed.search
-              : parsed.search;
-        } catch {
-          // malformed URL — leave actualHost/Port from the default
-        }
-      } else if (host.startsWith("ws://")) {
-        // Upgrade legacy ws:// to wss:// — unencrypted WebSockets are no longer supported
-        try {
-          const parsed = new URL(host);
-          actualHost = parsed.hostname;
-          actualPort = parsed.port ? Number.parseInt(parsed.port, 10) : port;
-          actualPath =
-            parsed.pathname !== "/"
-              ? parsed.pathname + parsed.search
-              : parsed.search;
-        } catch {
-          // malformed URL — leave actualHost/Port from the default
-        }
-      }
-
-      const url = `${protocol}://${actualHost}:${actualPort}${actualPath}`;
+      const target = resolveSocketTarget(host, port);
+      const url = target.url;
+      const actualHost = target.host;
+      const actualPort = target.port;
       const socket = createSocket(url);
 
       // Create server object immediately and add to servers map

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -19,6 +19,8 @@ export class TCPSocket implements ISocket {
   private isConnected = false;
   private _readyState = 0; // 0: CONNECTING, 1: OPEN, 2: CLOSING, 3: CLOSED
   private unlisten?: () => void;
+  private closeRequested = false;
+  private closeFinalized = false;
 
   public onopen: (() => void) | null = null;
   public onmessage: ((event: { data: string }) => void) | null = null;
@@ -43,6 +45,8 @@ export class TCPSocket implements ISocket {
       // Only handle messages for this client
       if (payload.id !== this.clientId) return;
 
+      if (this.closeFinalized) return;
+
       if (payload.event.message) {
         // Convert byte array to string
         const data = new TextDecoder().decode(
@@ -56,14 +60,15 @@ export class TCPSocket implements ISocket {
       }
 
       if (payload.event.connected === false) {
-        this.isConnected = false;
-        this._readyState = 3; // CLOSED
-        this.onclose?.();
-        this.unlisten?.();
-        this.unlisten = undefined;
+        this.finalizeClose();
       }
     })
       .then((unlistenFn) => {
+        if (this.closeFinalized) {
+          unlistenFn();
+          return;
+        }
+
         this.unlisten = unlistenFn;
       })
       .catch((error: unknown) => {
@@ -74,6 +79,23 @@ export class TCPSocket implements ISocket {
 
     invoke("connect", { clientId: this.clientId, address })
       .then(() => {
+        if (this.closeFinalized) {
+          return;
+        }
+
+        if (this.closeRequested) {
+          this.isConnected = true;
+
+          return invoke("disconnect", { clientId: this.clientId })
+            .then(() => {
+              this.finalizeClose();
+            })
+            .catch((error: unknown) => {
+              this.onerror?.(new Error(`Failed to disconnect: ${error}`));
+              this.finalizeClose();
+            });
+        }
+
         this.isConnected = true;
         this._readyState = 1; // OPEN
         // Start listening for messages
@@ -82,6 +104,11 @@ export class TCPSocket implements ISocket {
         this.onopen?.();
       })
       .catch((error: unknown) => {
+        if (this.closeRequested) {
+          this.finalizeClose();
+          return;
+        }
+
         this._readyState = 3; // CLOSED
         this.onerror?.(new Error(`Failed to connect: ${error}`));
       });
@@ -92,7 +119,7 @@ export class TCPSocket implements ISocket {
   }
 
   send(data: string): void {
-    if (!this.isConnected) {
+    if (!this.isConnected || this._readyState !== 1) {
       throw new Error("Socket is not connected");
     }
 
@@ -104,20 +131,42 @@ export class TCPSocket implements ISocket {
   }
 
   close(): void {
-    if (this.isConnected) {
+    if (this.closeRequested || this.closeFinalized) {
+      return;
+    }
+
+    this.closeRequested = true;
+
+    if (this._readyState !== 3) {
       this._readyState = 2; // CLOSING
+    }
+
+    if (this.isConnected) {
+      this.isConnected = false;
+
       invoke("disconnect", { clientId: this.clientId })
         .then(() => {
-          this.isConnected = false;
-          this._readyState = 3; // CLOSED
-          this.onclose?.();
-          this.unlisten?.();
-          this.unlisten = undefined;
+          this.finalizeClose();
         })
         .catch((error: unknown) => {
           this.onerror?.(new Error(`Failed to disconnect: ${error}`));
+          this.finalizeClose();
         });
     }
+  }
+
+  private finalizeClose(): void {
+    if (this.closeFinalized) {
+      return;
+    }
+
+    this.closeFinalized = true;
+    this.closeRequested = false;
+    this.isConnected = false;
+    this._readyState = 3;
+    this.onclose?.();
+    this.unlisten?.();
+    this.unlisten = undefined;
   }
 }
 

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -2,8 +2,16 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { parseIrcUrl } from "./ircUrlParser";
 
 type SocketProtocol = "wss" | "irc" | "ircs";
+
+export interface ResolvedSocketTarget {
+  url: string;
+  host: string;
+  port: number;
+  protocol: SocketProtocol;
+}
 
 export interface ISocket {
   onopen: (() => void) | null;
@@ -233,6 +241,42 @@ export function resolveSocketProtocol(url: string): SocketProtocol {
   }
 
   throw new Error("Unsupported socket protocol");
+}
+
+export function resolveSocketTarget(
+  rawHost: string,
+  port: number,
+): ResolvedSocketTarget {
+  let protocol: SocketProtocol = "wss";
+  let host = rawHost;
+  let resolvedPort = port;
+  let path = "";
+
+  if (rawHost.startsWith("irc://") || rawHost.startsWith("ircs://")) {
+    const parsed = parseIrcUrl(rawHost);
+    protocol = parsed.scheme;
+    host = parsed.host;
+    resolvedPort = parsed.port;
+  } else if (rawHost.startsWith("wss://") || rawHost.startsWith("ws://")) {
+    try {
+      const parsed = new URL(rawHost);
+      host = parsed.hostname;
+      resolvedPort = parsed.port ? Number.parseInt(parsed.port, 10) : port;
+      path =
+        parsed.pathname !== "/"
+          ? parsed.pathname + parsed.search
+          : parsed.search;
+    } catch {
+      // Keep the original host/port if the explicit websocket URL is malformed.
+    }
+  }
+
+  return {
+    url: `${protocol}://${host}:${resolvedPort}${path}`,
+    host,
+    port: resolvedPort,
+    protocol,
+  };
 }
 
 const defaultSocketFactory: SocketFactory = ({ url, protocol }) => {

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -3,6 +3,8 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 
+type SocketProtocol = "wss" | "irc" | "ircs";
+
 export interface ISocket {
   onopen: (() => void) | null;
   onmessage: ((event: { data: string }) => void) | null;
@@ -13,6 +15,13 @@ export interface ISocket {
   close(): void;
   readyState: number;
 }
+
+export interface SocketFactoryContext {
+  url: string;
+  protocol: SocketProtocol;
+}
+
+export type SocketFactory = (context: SocketFactoryContext) => ISocket;
 
 export class TCPSocket implements ISocket {
   private clientId: string;
@@ -210,12 +219,42 @@ export class WebSocketWrapper implements ISocket {
   }
 }
 
-export function createSocket(url: string): ISocket {
+export function resolveSocketProtocol(url: string): SocketProtocol {
   if (url.startsWith("wss://")) {
+    return "wss";
+  }
+
+  if (url.startsWith("irc://")) {
+    return "irc";
+  }
+
+  if (url.startsWith("ircs://")) {
+    return "ircs";
+  }
+
+  throw new Error("Unsupported socket protocol");
+}
+
+const defaultSocketFactory: SocketFactory = ({ url, protocol }) => {
+  if (protocol === "wss") {
     return new WebSocketWrapper(url);
   }
-  if (url.startsWith("irc://") || url.startsWith("ircs://")) {
-    return new TCPSocket(url);
-  }
-  throw new Error("Unsupported socket protocol");
+
+  return new TCPSocket(url);
+};
+
+let socketFactory: SocketFactory = defaultSocketFactory;
+
+export function setSocketFactory(factory: SocketFactory): void {
+  socketFactory = factory;
+}
+
+export function resetSocketFactory(): void {
+  socketFactory = defaultSocketFactory;
+}
+
+export function createSocket(url: string): ISocket {
+  const protocol = resolveSocketProtocol(url);
+
+  return socketFactory({ url, protocol });
 }

--- a/tests/lib/ircClient.test.ts
+++ b/tests/lib/ircClient.test.ts
@@ -166,6 +166,63 @@ describe("IRCClient", () => {
     });
   });
 
+  describe("disconnect", () => {
+    test("does not send QUIT while socket is still connecting", () => {
+      const mockSocket = new MockWebSocket("wss://irc.example.com:443");
+      MockWebSocketSpy.mockReturnValue(mockSocket);
+
+      client.connect(
+        "Test Server",
+        "irc.example.com",
+        443,
+        "testuser",
+        undefined,
+        undefined,
+        undefined,
+        "server-1",
+      );
+
+      client.disconnect("server-1");
+
+      expect(mockSocket.sentMessages).toEqual([]);
+      expect(mockSocket.readyState).toBe(WebSocket.CLOSED);
+    });
+
+    test("does not start reconnection after an intentional disconnect", async () => {
+      vi.useFakeTimers();
+
+      const mockSocket = new MockWebSocket("wss://irc.example.com:443");
+      MockWebSocketSpy.mockReturnValue(mockSocket);
+
+      const states: string[] = [];
+      client.on("connectionStateChange", ({ connectionState }) => {
+        states.push(connectionState);
+      });
+
+      const connectionPromise = client.connect(
+        "Test Server",
+        "irc.example.com",
+        443,
+        "testuser",
+        undefined,
+        undefined,
+        undefined,
+        "server-2",
+      );
+
+      mockSocket.simulateOpen();
+      await connectionPromise;
+
+      client.disconnect("server-2");
+      vi.runOnlyPendingTimers();
+
+      expect(states).toEqual(["connected", "disconnected"]);
+      expect(MockWebSocketSpy).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+  });
+
   describe("message handling", () => {
     test("should handle PRIVMSG correctly", async () => {
       const mockSocket = new MockWebSocket("ws://irc.example.com:443");

--- a/tests/lib/ircClient.test.ts
+++ b/tests/lib/ircClient.test.ts
@@ -102,6 +102,30 @@ describe("IRCClient", () => {
       expect(mockSocket.sentMessages).toContain("CAP LS 302");
     });
 
+    test("preserves secure websocket paths and query strings through the transport seam", async () => {
+      const mockSocket = new MockWebSocket(
+        "wss://irc.example.com:443/webirc?token=abc",
+      );
+      MockWebSocketSpy.mockReturnValue(mockSocket);
+
+      const connectionPromise = client.connect(
+        "WebIRC",
+        "wss://irc.example.com/webirc?token=abc",
+        443,
+        "testuser",
+      );
+
+      mockSocket.simulateOpen();
+      const server = await connectionPromise;
+
+      expect(MockWebSocketSpy).toHaveBeenCalledWith(
+        "wss://irc.example.com:443/webirc?token=abc",
+      );
+      expect(server.host).toBe("irc.example.com");
+      expect(server.port).toBe(443);
+      expect(server.name).toBe("WebIRC");
+    });
+
     test.skip("should handle connection errors", async () => {
       vi.useFakeTimers();
 

--- a/tests/lib/ircClient.test.ts
+++ b/tests/lib/ircClient.test.ts
@@ -221,6 +221,45 @@ describe("IRCClient", () => {
 
       vi.useRealTimers();
     });
+
+    test("treats closing sockets as intentional disconnects", async () => {
+      vi.useFakeTimers();
+
+      const mockSocket = new MockWebSocket("wss://irc.example.com:443");
+      MockWebSocketSpy.mockReturnValue(mockSocket);
+
+      const states: string[] = [];
+      client.on("connectionStateChange", ({ connectionState }) => {
+        states.push(connectionState);
+      });
+
+      const connectionPromise = client.connect(
+        "Test Server",
+        "irc.example.com",
+        443,
+        "testuser",
+        undefined,
+        undefined,
+        undefined,
+        "server-3",
+      );
+
+      mockSocket.simulateOpen();
+      await connectionPromise;
+
+      mockSocket.readyState = WebSocket.CLOSING;
+      client.disconnect("server-3");
+      mockSocket.onclose?.(new CloseEvent("close"));
+      vi.runOnlyPendingTimers();
+
+      expect(states).toEqual(["connected", "disconnected"]);
+      expect(mockSocket.sentMessages).not.toContain(
+        "QUIT :ObsidianIRC - Bringing IRC to the future",
+      );
+      expect(MockWebSocketSpy).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
   });
 
   describe("message handling", () => {

--- a/tests/lib/socket.test.ts
+++ b/tests/lib/socket.test.ts
@@ -17,6 +17,7 @@ import {
   createSocket,
   resetSocketFactory,
   resolveSocketProtocol,
+  resolveSocketTarget,
   setSocketFactory,
   TCPSocket,
 } from "../../src/lib/socket";
@@ -160,6 +161,39 @@ describe("TCPSocket", () => {
     expect(() => resolveSocketProtocol("https://example.com/socket")).toThrow(
       "Unsupported socket protocol",
     );
+  });
+
+  test("resolveSocketTarget preserves secure websocket paths and query strings", () => {
+    expect(
+      resolveSocketTarget("wss://irc.example.com/webirc?token=abc", 443),
+    ).toEqual({
+      url: "wss://irc.example.com:443/webirc?token=abc",
+      host: "irc.example.com",
+      port: 443,
+      protocol: "wss",
+    });
+  });
+
+  test("resolveSocketTarget upgrades ws urls to the secure websocket transport", () => {
+    expect(resolveSocketTarget("ws://irc.example.com/socket?x=1", 443)).toEqual(
+      {
+        url: "wss://irc.example.com:443/socket?x=1",
+        host: "irc.example.com",
+        port: 443,
+        protocol: "wss",
+      },
+    );
+  });
+
+  test("resolveSocketTarget keeps irc and ircs parsing in the transport seam", () => {
+    expect(
+      resolveSocketTarget("ircs://irc.libera.chat:6697/#chat", 443),
+    ).toEqual({
+      url: "ircs://irc.libera.chat:6697",
+      host: "irc.libera.chat",
+      port: 6697,
+      protocol: "ircs",
+    });
   });
 
   test("close during connect suppresses a later onopen", async () => {

--- a/tests/lib/socket.test.ts
+++ b/tests/lib/socket.test.ts
@@ -13,7 +13,13 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: listenMock,
 }));
 
-import { TCPSocket } from "../../src/lib/socket";
+import {
+  createSocket,
+  resetSocketFactory,
+  resolveSocketProtocol,
+  setSocketFactory,
+  TCPSocket,
+} from "../../src/lib/socket";
 
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -80,6 +86,80 @@ describe("TCPSocket", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    resetSocketFactory();
+  });
+
+  test("allows a custom socket factory to be injected", () => {
+    const fakeSocket = {
+      onopen: null,
+      onmessage: null,
+      onerror: null,
+      onclose: null,
+      send: vi.fn(),
+      close: vi.fn(),
+      readyState: 1,
+    };
+
+    const factory = vi.fn(() => fakeSocket);
+    setSocketFactory(factory);
+
+    const socket = createSocket("ircs://irc.example.com:6697");
+
+    expect(factory).toHaveBeenCalledWith({
+      url: "ircs://irc.example.com:6697",
+      protocol: "ircs",
+    });
+    expect(socket).toBe(fakeSocket);
+  });
+
+  test("reset restores the default websocket routing", () => {
+    const sentinelFactory = vi.fn(() => {
+      throw new Error("custom factory should have been reset");
+    });
+
+    class MockSocket extends EventTarget {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSING = 2;
+      static readonly CLOSED = 3;
+
+      readyState = MockSocket.CONNECTING;
+      onopen = null;
+      onmessage = null;
+      onerror = null;
+      onclose = null;
+
+      constructor(public url: string) {
+        super();
+      }
+
+      send() {}
+      close() {}
+    }
+
+    const originalWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = MockSocket as unknown as typeof WebSocket;
+
+    setSocketFactory(sentinelFactory);
+    resetSocketFactory();
+
+    const socket = createSocket("wss://irc.example.com/webirc");
+
+    expect(sentinelFactory).not.toHaveBeenCalled();
+    expect(socket.constructor.name).toBe("WebSocketWrapper");
+
+    if (originalWebSocket) {
+      globalThis.WebSocket = originalWebSocket;
+    }
+  });
+
+  test("resolveSocketProtocol preserves current supported routing", () => {
+    expect(resolveSocketProtocol("wss://irc.example.com/webirc")).toBe("wss");
+    expect(resolveSocketProtocol("irc://irc.example.com:6667")).toBe("irc");
+    expect(resolveSocketProtocol("ircs://irc.example.com:6697")).toBe("ircs");
+    expect(() => resolveSocketProtocol("https://example.com/socket")).toThrow(
+      "Unsupported socket protocol",
+    );
   });
 
   test("close during connect suppresses a later onopen", async () => {

--- a/tests/lib/socket.test.ts
+++ b/tests/lib/socket.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const { invokeMock, listenMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  listenMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: listenMock,
+}));
+
+import { TCPSocket } from "../../src/lib/socket";
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks(iterations = 5): Promise<void> {
+  for (let index = 0; index < iterations; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+function getClientId(socket: TCPSocket): string {
+  return (socket as unknown as { clientId: string }).clientId;
+}
+
+describe("TCPSocket", () => {
+  let connectDeferred: ReturnType<typeof createDeferred<void>>;
+  let unlistenMock: ReturnType<typeof vi.fn>;
+  let tcpMessageListener:
+    | ((event: {
+        payload: {
+          id: string;
+          event: {
+            message?: { data: number[] };
+            error?: string;
+            connected?: boolean;
+          };
+        };
+      }) => void)
+    | undefined;
+
+  beforeEach(() => {
+    connectDeferred = createDeferred<void>();
+    unlistenMock = vi.fn();
+    tcpMessageListener = undefined;
+
+    listenMock.mockImplementation(async (_eventName, handler) => {
+      tcpMessageListener = handler;
+      return unlistenMock;
+    });
+
+    invokeMock.mockImplementation((command: string, payload?: unknown) => {
+      switch (command) {
+        case "connect":
+          return connectDeferred.promise;
+        case "listen":
+          return Promise.resolve();
+        case "disconnect":
+          return Promise.resolve(payload);
+        case "send":
+          return Promise.resolve(payload);
+        default:
+          return Promise.resolve();
+      }
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("close during connect suppresses a later onopen", async () => {
+    const socket = new TCPSocket("irc://irc.example.com:6667");
+    const onopen = vi.fn();
+    const onclose = vi.fn();
+    socket.onopen = onopen;
+    socket.onclose = onclose;
+
+    socket.close();
+
+    expect(socket.readyState).toBe(2);
+
+    connectDeferred.resolve();
+    await flushMicrotasks();
+
+    expect(invokeMock).toHaveBeenCalledWith("disconnect", {
+      clientId: getClientId(socket),
+    });
+    expect(onopen).not.toHaveBeenCalled();
+    expect(onclose).toHaveBeenCalledTimes(1);
+    expect(socket.readyState).toBe(3);
+  });
+
+  test("local close only emits onclose once when backend close arrives late", async () => {
+    const socket = new TCPSocket("irc://irc.example.com:6667");
+    const onclose = vi.fn();
+    socket.onclose = onclose;
+
+    connectDeferred.resolve();
+    await flushMicrotasks();
+
+    socket.close();
+    await flushMicrotasks();
+
+    tcpMessageListener?.({
+      payload: {
+        id: getClientId(socket),
+        event: { connected: false },
+      },
+    });
+
+    expect(onclose).toHaveBeenCalledTimes(1);
+    expect(unlistenMock).toHaveBeenCalledTimes(1);
+    expect(socket.readyState).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

This PR has grown beyond the original disconnect-only hardening and now prepares ObsidianIRC's transport stack for a future native backend without changing the current default behavior.

In practical terms, this PR:

- hardens intentional disconnect vs unexpected close handling in `IRCClient`
- makes the frontend socket lifecycle more idempotent in `src/lib/socket.ts`
- makes the Tauri Rust bridge shutdown/removal path idempotent in `src-tauri/src/socket.rs`
- extracts an explicit transport seam so future native transport work can plug in below the current IRC logic
- updates architecture docs so they match the real web/native transport split

## Why

ObsidianIRC already has a split transport model:

- browser-compatible paths use `wss://`
- desktop/native paths use `irc://` / `ircs://` through the Tauri socket bridge

The previous code still mixed transport lifecycle concerns across layers, which made a few things harder than they should be:

- distinguishing intentional disconnects from connection loss
- keeping close/shutdown behavior idempotent
- testing transport edges in isolation
- preparing a future native transport backend without rewriting `IRCClient`

This PR fixes those lifecycle edges first, then opens a seam for the next step.

## What Changed

### 1. `IRCClient` lifecycle hardening

In `src/lib/irc/IRCClient.ts`:

- intentional disconnects are tracked explicitly
- manual disconnects no longer trigger unwanted reconnection attempts
- sockets already in `CLOSING` are still treated as intentional disconnects
- disconnect behavior is safer during connection initialization
- transport target resolution now comes from the socket layer instead of being assembled inline in `IRCClient`

### 2. Frontend socket seam + lifecycle hardening

In `src/lib/socket.ts`:

- `TCPSocket` close handling is now idempotent
- closing during `CONNECTING` no longer results in a late `onopen`
- duplicate close handling is suppressed when backend close signals arrive late
- routing/factory logic is now explicit through:
  - `resolveSocketProtocol()`
  - `resolveSocketTarget()`
  - `SocketFactory`
  - `setSocketFactory()` / `resetSocketFactory()`

This keeps the current routing intact while making future transport injection cleaner:

- `wss://` -> `WebSocketWrapper`
- `irc://` / `ircs://` -> `TCPSocket`

### 3. Tauri Rust bridge hardening

In `src-tauri/src/socket.rs`:

- connection removal is centralized through `take_connection()`
- late read/shutdown paths do not re-handle already-removed connections
- `disconnect()` is now idempotent from the bridge's point of view
- added a focused Rust test for idempotent connection removal

### 4. Architecture documentation

In `ARCHITECTURE.md`:

- corrected the old "websockets only" framing
- documented the real split between web websocket transport and native Tauri TCP/TLS transport
- clarified where future transport work belongs

## Transport Layout

```mermaid
flowchart LR
  A[IRCClient] --> B[resolveSocketTarget in socket.ts]
  B --> C[createSocket / SocketFactory]
  C --> D[WebSocketWrapper]
  C --> E[TCPSocket]
  E --> F[Tauri invoke bridge]
  F --> G[src-tauri/src/socket.rs]
  D --> H[(IRC/WebSocket endpoint)]
  G --> I[(IRC TCP/TLS endpoint)]
  J[Future native transport backend PR] -. plugs in behind seam .-> C
```

## Tests / Validation

### TypeScript / frontend transport slice

- `npm run test -- tests/lib/ircClient.test.ts tests/lib/socket.test.ts`
- `npm run build`

### Rust bridge slice

- `cd src-tauri && cargo test`

### Focused coverage added in this PR

- intentional disconnect regression coverage in `tests/lib/ircClient.test.ts`
- transport seam and lifecycle coverage in `tests/lib/socket.test.ts`
- Rust idempotency coverage in `src-tauri/src/socket.rs`

## Scope Boundary

This PR **does not** introduce a new native transport backend yet.

Instead, it does the prep work needed so the next branch/PR can implement one more safely:

- lifecycle semantics are more stable
- transport routing is more explicit
- frontend and Rust bridge responsibilities are clearer
- tests exist around the edges most likely to regress

## Follow-Up

The natural next branch after this one is a focused native transport backend experiment that plugs in behind the seam added here, rather than changing `IRCClient` protocol logic again.

That follow-up should be able to build directly on:

- `resolveSocketTarget()`
- `SocketFactory`
- the `TCPSocket`/bridge lifecycle hardening
- the idempotent Rust-side connection removal path
