### PR TITLE
add stalebot

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,42 @@
+name: Stale Pull Requests
+
+on:
+  schedule:
+    - cron: "30 7 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List what would be marked or closed without touching anything"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
+        with:
+          days-before-pr-stale: 30
+          days-before-pr-close: 60
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          stale-pr-label: stale
+          # Dependabot recreates a PR it did not close itself, so closing one
+          # here buys a duplicate on the next run.
+          exempt-pr-labels: "dependencies,pinned"
+          # Oldest first, so the ones nearest closing are handled even if a run
+          # hits the operation budget.
+          ascending: true
+          operations-per-run: 100
+          debug-only: ${{ inputs.dry_run == true }}
+          stale-pr-message: >
+            No activity here for a month. Add the `pinned` label or leave a
+            comment to keep it open, otherwise this closes in 60 days.
+          close-pr-message: >
+            Closing after three months without activity. Reopen it whenever you
+            want to pick it back up.


### PR DESCRIPTION
Runs `actions/stale` once a day. A pull request with no activity for a month gets labelled and a comment saying it closes in 60 days. Any comment, push or review clears the label and resets the clock.

The two timers chain, so nothing closes before it has been idle three months. On the first run the ten PRs already past a month get labelled, and the earliest close date is late October.

- Issues are left alone.
- Dependabot is exempt. It recreates a PR it did not close itself, so closing one just gets a duplicate back.
- The `pinned` label keeps a PR open forever.
- Run it by hand with `dry_run` ticked to see what it would touch without touching anything.

Create the `stale` and `pinned` labels before merging. The REST docs do not say what happens when the action applies a label the repo does not have.
